### PR TITLE
Ugs codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+# Use the official Ubuntu Jammy-based Dev Container image as a starting point
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+# 1. Install dependencies needed to add Intel’s repo, install CMake, gfortran, and GDB
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        wget \
+        gpg \
+        lsb-release \
+        apt-transport-https \
+        ca-certificates \
+        cmake \
+        gdb \
+        gfortran \
+        && rm -rf /var/lib/apt/lists/*
+
+# 2. Add Intel’s GPG key and repository for oneAPI
+RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+    | gpg --dearmor \
+    | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+RUN echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+    > /etc/apt/sources.list.d/oneAPI.list
+
+# 3. Install Intel oneAPI Fortran Compiler
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        intel-oneapi-compiler-fortran \
+        && rm -rf /var/lib/apt/lists/*
+
+# 4. Source Intel’s setvars script automatically for all users
+#    (In a dev container, /etc/bash.bashrc is typically read by non-login shells)
+RUN echo "source /opt/intel/oneapi/setvars.sh" >> /etc/bash.bashrc
+
+# 5. Prepend ifx path to the global PATH environment
+ENV PATH=/opt/intel/oneapi/compiler/2025.0/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.0/lib:$LD_LIBRARY_PATH
+
+# That’s it! The container now has ifx + CMake installed and configured.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// .devcontainer/devcontainer.json
+{
+	"name": "Intel Fortran Dev Container",
+	// 1. Build our custom Dockerfile
+	"build": {
+	  "dockerfile": "Dockerfile"
+	},
+	"postCreateCommand": "mkdir -p /workspaces/data_test && cp -r /workspaces/*/data/Ames_sub1 /workspaces/data_test/",
+	// 2. VS Code customizations
+	"customizations": {
+	  "vscode": {
+		// 2A. Install relevant extensions automatically
+		"extensions": [
+		  "ms-vscode.cmake-tools",
+		  "fortran-lang.linter-gfortran",
+		  "ms-vscode.cpptools",
+		  "mhutchie.git-graph",
+		  "GitHub.remotehub"
+		],
+		// 2B. VS Code settings for CMake + ifx
+		"settings": {
+		  "cmake.cmakePath": "/usr/bin/cmake",
+		  "cmake.configureSettings": {
+			// If you want to always use ifx in your CMake configs
+			"CMAKE_Fortran_COMPILER": "ifx"
+		  },
+		  "cmake.environment": {
+			// Additional environment variables for Fortran
+			"FC": "ifx",
+			// Not strictly needed if your Dockerfile sets PATH/LD_LIBRARY_PATH
+			"PATH": "/opt/intel/oneapi/compiler/2025.0/bin:${env:PATH}",
+			"LD_LIBRARY_PATH": "/opt/intel/oneapi/compiler/2025.0/lib:${env:LD_LIBRARY_PATH}"
+		  }
+		}
+	  }
+	}
+  }


### PR DESCRIPTION
This pull request introduces several updates that allow a user to launch a prebuilt Codespace with minimal configuration.

The only change required by the user is to update the working directory in launch.json to point to the pre-copied dataset. For example:

"cwd": "/workspaces/data_test/Ames_sub1"

During the initial setup of the dev container, the existing Ames dataset is automatically copied to /workspaces/data_test. This eliminates the need for manual dataset configuration and ensures that the correct data is available when the Codespace starts.

IFX and gfortran work in this codespace... there seems to be no debug issues using ifx in this setup...

As simple as 1,2,3

![Screenshot 2025-03-12 150029](https://github.com/user-attachments/assets/e9c017ec-8027-4fec-85a0-f1eeca21b367)



