### PR TITLE
Merge 0417

### DIFF
--- a/src/aqu_1d_control.f90
+++ b/src/aqu_1d_control.f90
@@ -25,7 +25,7 @@
       integer :: ipest = 0      !none       |counter
       integer :: ipest_db = 0   !none       |pesticide number from pesticide data base
       integer :: ipseq = 0      !none       |sequential basin pesticide number
-      integer :: ipdb = 0       !none       |sequential pesticide number of daughter pesticide
+      integer :: ipdb = 0       !none       |seqential pesticide number of daughter pesticide
       integer :: imeta = 0      !none       |pesticide metabolite counter
       real :: mol_wt_rto = 0.   !ratio      |molecular weight ratio of duaghter to parent pesticide
       real :: stor_init = 0.    !           |
@@ -93,7 +93,7 @@
       aqu_d(iaq)%dep_wt = aqu_dat(iaq)%dep_bot - (aqu_d(iaq)%stor / (1000. * aqu_dat(iaq)%spyld))
       aqu_d(iaq)%dep_wt = max (0., aqu_d(iaq)%dep_wt)
 
-      !! compute flow and subtract from storage
+      !! compute flow and substract from storage
       if (aqu_d(iaq)%dep_wt <= aqu_dat(iaq)%flo_min) then
         aqu_d(iaq)%flo = aqu_d(iaq)%flo * aqu_prm(iaq)%alpha_e + aqu_d(iaq)%rchrg * (1. - aqu_prm(iaq)%alpha_e)
         aqu_d(iaq)%flo = Max (0., aqu_d(iaq)%flo)
@@ -295,7 +295,7 @@
         
         !! compute pesticide decay in the aquifer
         aqupst_d(iaq)%pest(ipest)%react = 0.
-        if (cs_aqu(iaq)%pest(ipest) > 1.e-12) then
+        if (cs_aqu(iaq)%pest(ipest) > 0.) then
           aqupst_d(iaq)%pest(ipest)%react = cs_aqu(iaq)%pest(ipest) * (1. - pestcp(ipest_db)%decay_s)
           cs_aqu(iaq)%pest(ipest) =  cs_aqu(iaq)%pest(ipest) * pestcp(ipest_db)%decay_s
           !! add decay to daughter pesticides

--- a/src/aqu_1d_control.f90
+++ b/src/aqu_1d_control.f90
@@ -25,7 +25,7 @@
       integer :: ipest = 0      !none       |counter
       integer :: ipest_db = 0   !none       |pesticide number from pesticide data base
       integer :: ipseq = 0      !none       |sequential basin pesticide number
-      integer :: ipdb = 0       !none       |seqential pesticide number of daughter pesticide
+      integer :: ipdb = 0       !none       |sequential pesticide number of daughter pesticide
       integer :: imeta = 0      !none       |pesticide metabolite counter
       real :: mol_wt_rto = 0.   !ratio      |molecular weight ratio of duaghter to parent pesticide
       real :: stor_init = 0.    !           |
@@ -93,7 +93,7 @@
       aqu_d(iaq)%dep_wt = aqu_dat(iaq)%dep_bot - (aqu_d(iaq)%stor / (1000. * aqu_dat(iaq)%spyld))
       aqu_d(iaq)%dep_wt = max (0., aqu_d(iaq)%dep_wt)
 
-      !! compute flow and substract from storage
+      !! compute flow and subtract from storage
       if (aqu_d(iaq)%dep_wt <= aqu_dat(iaq)%flo_min) then
         aqu_d(iaq)%flo = aqu_d(iaq)%flo * aqu_prm(iaq)%alpha_e + aqu_d(iaq)%rchrg * (1. - aqu_prm(iaq)%alpha_e)
         aqu_d(iaq)%flo = Max (0., aqu_d(iaq)%flo)

--- a/src/basin_module.f90
+++ b/src/basin_module.f90
@@ -166,7 +166,7 @@
       ! SPECIAL OUTPUTS
         character(len=1) :: csvout   = "n"            !!  code to print .csv files n=no print; y=print;
         ! character(len=1) :: carbout  = "n"         !!  code to print carbon output; d = end of day; m = end of month; y = end of year; a = end of simulation;
-          character(len=1) :: use_obj_labels  = "n"    !!  code to read in the print.prt print objects respecting the label of 
+        character(len=1) :: use_obj_labels  = "n"    !!  code to read in the print.prt print objects respecting the label of 
                                                      !!  in the row (1st column) to identify name of the print object 
 
         character(len=1) :: cdfout   = "n"            !!  code to print netcdf (cdf) files n=no print; y=print;

--- a/src/basin_module.f90
+++ b/src/basin_module.f90
@@ -166,7 +166,7 @@
       ! SPECIAL OUTPUTS
         character(len=1) :: csvout   = "n"            !!  code to print .csv files n=no print; y=print;
         ! character(len=1) :: carbout  = "n"         !!  code to print carbon output; d = end of day; m = end of month; y = end of year; a = end of simulation;
-        character(len=1) :: use_obj_labels  = "n"    !!  code to read in the print.prt print objects respecting the label of 
+          character(len=1) :: use_obj_labels  = "n"    !!  code to read in the print.prt print objects respecting the label of 
                                                      !!  in the row (1st column) to identify name of the print object 
 
         character(len=1) :: cdfout   = "n"            !!  code to print netcdf (cdf) files n=no print; y=print;

--- a/src/cal_conditions.f90
+++ b/src/cal_conditions.f90
@@ -45,7 +45,7 @@
       integer :: icom = 0
          
       do ichg_par = 1, db_mx%cal_upd
-          !print *, "debug ", ichg_par
+
         do ispu = 1, cal_upd(ichg_par)%num_elem
           ielem = cal_upd(ichg_par)%num(ispu)
           chg_parm = cal_upd(ichg_par)%name
@@ -98,7 +98,7 @@
             case ("cal_group")     !for hru    
               if (cal_upd(ichg_par)%cond(ic)%targc /= hru(ielem)%cal_group) then 
                 cond_met = "n"
-                exit
+                !exit
               end if
             end select
           end do    ! ic - conditions

--- a/src/cal_conditions.f90
+++ b/src/cal_conditions.f90
@@ -45,6 +45,7 @@
       integer :: icom = 0
          
       do ichg_par = 1, db_mx%cal_upd
+          !print *, "debug ", ichg_par
         do ispu = 1, cal_upd(ichg_par)%num_elem
           ielem = cal_upd(ichg_par)%num(ispu)
           chg_parm = cal_upd(ichg_par)%name

--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -98,13 +98,13 @@
        integer :: j = 0          !                     |number of hru
        integer :: k = 0          !none                 |counte
        integer :: kk = 0         !                     |
-       integer :: lmnta = 0      !                     |      
+       real :: lmnta = 0      !                     |      
        real :: min_n_ppm = 0  !                     |
-       integer :: lslncat = 0    !                     |
+       real :: lslncat = 0    !                     |
        real :: min_n = 0      !                     |
-       integer :: cf_lyr         !                     |hich layer of coefs to use in carbon_coef.cbn
-       integer :: bmix_depth     !mm                   !depth of biological
-       integer :: soil_lyr_thickness !mm
+       integer :: cf_lyr         !                     |which layer of coefs to use in carbon_coef.cbn
+       real :: bmix_depth     !mm                   !depth of biological
+       real :: soil_lyr_thickness !mm
        real :: sol_mass = 0.     !                     |
        real :: sol_min_n = 0.    !                     |
        real :: fc = 0.           !mm H2O               |amount of water available to plants in soil layer at field capacity (fc - wp),Index:(layer,HRU)

--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -6,8 +6,7 @@
         use organic_mineral_mass_module
         use carbon_module
         use output_landscape_module
-        use tillage_data_module
-        use time_module, only : time   ! this only used for debugging purposes in with an IDE with conditional breakpoints.
+        use time_module, only : time
         
         implicit none
         
@@ -103,7 +102,8 @@
        real :: min_n_ppm = 0  !                     |
        integer :: lslncat = 0    !                     |
        real :: min_n = 0      !                     |
-       integer :: cf_lyr         !                     |which layer of coefs to use in carbon_coef.cbn
+       integer :: cf_lyr         !                     |hich layer of coefs to use in carbon_coef.cbn
+       integer :: bmix_depth     !mm                   !depth of biological
        integer :: soil_lyr_thickness !mm
        real :: sol_mass = 0.     !                     |
        real :: sol_min_n = 0.    !                     |
@@ -182,9 +182,7 @@
        real :: rmp = 0.          !kg P/ha              |amount of phosphorus moving from fresh organic
        real :: rto = 0.          !none                 |cloud cover factor
        real :: rspc = 0.         !                     |
-       real :: xx = 0.           !varies               |variable to hold calculation results
-      !  real :: bmix_eff          !                     |biological mixing efficiency
-      !  real :: bmix_depth        !mm                   !depth of biological
+       real :: xx = 0.           !varies    |variable to hold calculation results
        logical :: ufc = .false. !Use File Coefficients (ufc) from carbon_coef.cbn file
 
        ufc = carbon_coef_file
@@ -251,12 +249,8 @@
        cpn5 = 0.
        wmin = 0.
        dmdn = 0.
+       bmix_depth = 50    
        soil_lyr_thickness = 0
-
-      !  if (bmix_idtill == 0) then
-      !   bmix_eff = .2        
-      !   bmix_depth = 50.
-      !  endif
 
        j = ihru
        hrc_d(j)%rsd_surfdecay_c = 0.
@@ -315,7 +309,7 @@
           !!compute soil water factor - sut
           fc = soil(j)%phys(k)%fc + soil(j)%phys(k)%wpmm        ! units mm
           wc = soil(j)%phys(k)%st + soil(j)%phys(k)%wpmm        ! units mm
-          ! sat = soil(j)%phys(k)%ul + soil(j)%phys(k)%wpmm       ! units mm
+          sat = soil(j)%phys(k)%ul + soil(j)%phys(k)%wpmm       ! units mm
           ! void = soil(j)%phys(k)%por * (1. - wc / sat)          ! fraction
 
           if (wc - soil(j)%phys(k)%wpmm < 0.) then
@@ -357,8 +351,7 @@
               else
                 ! Changed by fg to always have some bio mixing
                 if (soil(j)%phys(k)%d <= bmix_depth) then            
-                  ! org_con%till_eff = 1.0 + hru(j)%hyd%biomix
-                  org_con%till_eff = 1.0 + bmix_eff
+                  org_con%till_eff = 1.0 + hru(j)%hyd%biomix
                 else
 
                   if (k == 1) then
@@ -368,7 +361,7 @@
                   end if
 
                   if (soil(j)%phys(k)%d > bmix_depth .and. soil(j)%phys(k-1)%d < bmix_depth) then 
-                    org_con%till_eff = 1.0 + (bmix_eff * (bmix_depth - soil(j)%phys(k-1)%d) / soil_lyr_thickness)  
+                    org_con%till_eff = 1.0 + (hru(j)%hyd%biomix * (bmix_depth - soil(j)%phys(k-1)%d) / soil_lyr_thickness)  
                   else
                     org_con%till_eff = 1.0
                   end if
@@ -434,11 +427,7 @@
             if (.not. ufc) org_allo(cf_lyr)%apco2 = .55
             org_ratio%nchp = .1
             xbm = 1.
-            ! org_con%cs = org_con%cs * carbdb(cf_lyr)%microb_top_rate, This was commented out by FG and JC because 
-            ! org_con%cs should not be reduced by the microb_top_rate for the surface layer  and instead the surface layer
-            ! should use the microb_top_rate in computing the potential microbial biomass transformation
-            ! later in code.
-
+            ! org_con%cs = org_con%cs * carbdb(cf_lyr)%microb_top_rate
             ! compute n/c ratios - relative nitrogen content in residue
             rsdn_pct = 0.1 * (soil1(j)%rsd(1)%n + soil1(j)%meta(1)%n) / (soil1(j)%rsd(1)%c / 1000. + 1.e-5)
             if (rsdn_pct > 2.) then
@@ -732,7 +721,7 @@
 	            lscta = min(soil1(j)%str(k)%c, lscta)              
               lslcta = min(soil1(j)%lig(k)%c, lslcta)
               
-              ! org_flux%co2fstr = .3 * lslcta
+              org_flux%co2fstr = .3 * lslcta
               org_flux%co2fstr = org_allo(cf_lyr)%a1co2 * lslncta
               
               org_flux%cfstrs1 = a1 * lslncta

--- a/src/ch_rtpest.f90
+++ b/src/ch_rtpest.f90
@@ -17,7 +17,7 @@
       integer :: ipest = 0      !none                   |pesticide counter - sequential
       integer :: jpst = 0       !none                   |pesticide counter from data base
       integer :: ipseq = 0      !none                   |sequential basin pesticide number
-      integer :: ipdb = 0       !none                   |seqential pesticide number of daughter pesticide
+      integer :: ipdb = 0       !none                   |sequential pesticide number of daughter pesticide
       integer :: imeta = 0      !none                   |pesticide metabolite counter
       real :: mol_wt_rto = 0.   !ratio                  |molecular weight ratio of duaghter to parent pesticide
       real :: pstin = 0.        !mg pst                 |total pesticide transported into reach during time step

--- a/src/ch_rtpest.f90
+++ b/src/ch_rtpest.f90
@@ -3,77 +3,6 @@
 !!     ~ ~ ~ PURPOSE ~ ~ ~
 !!     this subroutine computes the daily stream pesticide balance
 !!     (soluble and sorbed)     
-
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name          |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    chpst_conc(:) |mg/(m**3)     |initial pesticide concentration in reach
-!!    chpst_koc(:)  |m**3/g        |pesticide partition coefficient between
-!!                                 |water and sediment in reach
-!!    chpst_mix(:)  |m/day         |mixing velocity (diffusion/dispersion) for
-!!                                 |pesticide in reach
-!!    chpst_rea(:)  |1/day         |pesticide reaction coefficient in reach
-!!    chpst_rsp(:)  |m/day         |resuspension velocity in reach for pesticide
-!!                                 |sorbed to sediment
-!!    chpst_stl(:)  |m/day         |settling velocity in reach for pesticide
-!!                                 |sorbed to sediment
-!!    chpst_vol(:)  |m/day         |pesticide volatilization coefficient in 
-!!                                 |reach
-!!    drift(:)      |kg            |amount of pesticide drifting onto main
-!!                                 |channel in subbasin
-!!    rchdep        |m             |depth of flow on day
-!!    rchwtr        |m^3 H2O       |water stored in reach at beginning of day
-!!    sedpst_rea(:) |1/day         |pesticide reaction coefficient in river bed
-!!                                 |sediment
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    ~ ~ ~ OUTGOING VARIABLES ~ ~ ~
-!!    name        |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    bury        |mg pst        |loss of pesticide from active sediment layer
-!!                               |by burial
-!!    difus       |mg pst        |diffusion of pesticide from sediment to reach
-!!    reactb      |mg pst        |amount of pesticide in sediment that is lost
-!!                               |through reactions
-!!    reactw      |mg pst        |amount of pesticide in reach that is lost
-!!                               |through reactions
-!!    resuspst    |mg pst        |amount of pesticide moving from sediment to
-!!                               |reach due to resuspension
-!!    setlpst     |mg pst        |amount of pesticide moving from water to
-!!                               |sediment due to settling
-!!    solpesto    |mg pst/m^3    |soluble pesticide concentration in outflow
-!!                               |on day
-!!    sorpesto    |mg pst/m^3    |sorbed pesticide concentration in outflow
-!!                               |on day
-!!    volatpst    |mg pst        |amount of pesticide in reach lost by
-!!                               |volatilization
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-
-!!    ~ ~ ~ LOCAL DEFINITIONS ~ ~ ~
-!!    name        |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    chpstmass   |mg pst        |mass of pesticide in reach
-!!    depth       |m             |depth of water in reach
-!!    fd2         |
-!!    frsol       |none          |fraction of pesticide in reach that is soluble
-!!    frsrb       |none          |fraction of pesticide in reach that is sorbed
-!!    jrch        |none          |reach number
-!!    pstin       |mg pst        |total pesticide transported into reach
-!!                               |during time step
-!!    sedcon      |g/m^3         |sediment concentration
-!!    sedpstmass  |mg pst        |mass of pesticide in bed sediment
-!!    solpstin    |mg pst        |soluble pesticide entering reach during 
-!!                               |time step
-!!    sorpstin    |mg pst        |sorbed pesticide entering reach during
-!!                               |time step
-!!    tday        |days          |flow duration
-!!    wtrin       |m^3 H2O       |volume of water entering reach during time
-!!                               |step
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-
-!!    ~ ~ ~ SUBROUTINES/FUNCTIONS CALLED ~ ~ ~
-!!    Intrinsic: Abs
-
-!!    ~ ~ ~ ~ ~ ~ END SPECIFICATIONS ~ ~ ~ ~ ~ ~
       
       use channel_data_module
       use channel_module
@@ -88,7 +17,7 @@
       integer :: ipest = 0      !none                   |pesticide counter - sequential
       integer :: jpst = 0       !none                   |pesticide counter from data base
       integer :: ipseq = 0      !none                   |sequential basin pesticide number
-      integer :: ipdb = 0       !none                   |sequential pesticide number of daughter pesticide
+      integer :: ipdb = 0       !none                   |seqential pesticide number of daughter pesticide
       integer :: imeta = 0      !none                   |pesticide metabolite counter
       real :: mol_wt_rto = 0.   !ratio                  |molecular weight ratio of duaghter to parent pesticide
       real :: pstin = 0.        !mg pst                 |total pesticide transported into reach during time step

--- a/src/mgt_newtillmix.f90
+++ b/src/mgt_newtillmix.f90
@@ -57,6 +57,9 @@
       real :: mix_clay
       real :: mix_silt
       real :: mix_sand
+      real :: mix_sw
+      real :: mix_rock
+      real :: mix_bd
 
       npmx = cs_db%num_pests
 
@@ -74,6 +77,12 @@
       mix_org%meta = orgz
       mix_org%man = orgz
       mix_org%water = orgz
+      mix_clay = 0.
+      mix_silt = 0.
+      mix_sand = 0.
+      mix_rock = 0.
+      mix_sw = 0.
+      mix_bd = 0.
     
       frac_mixed = 0.
       frac_non_mixed = 0.
@@ -142,6 +151,13 @@
           !! calculate the mass each mixed element
           frac_mixed = sol_msm(l) / sol_mass(l)
           
+          mix_sw = mix_sw + frac_mixed * soil(jj)%phys(l)%st
+          mix_bd = mix_bd + frac_mixed * soil(jj)%phys(l)%bd
+          mix_rock = mix_rock + frac_mixed * soil(jj)%phys(l)%rock
+          mix_sand = mix_sand + frac_mixed * soil(jj)%phys(l)%sand
+          mix_silt = mix_silt + frac_mixed * soil(jj)%phys(l)%silt
+          mix_clay = mix_clay + frac_mixed * soil(jj)%phys(l)%clay
+          
           mix_mn = mix_mn + frac_mixed * soil1(jj)%mn(l)
           mix_mp = mix_mp + frac_mixed * soil1(jj)%mp(l)
           mix_org%tot = mix_org%tot + frac_mixed * soil1(jj)%tot(l)
@@ -158,13 +174,7 @@
           mix_org%water = mix_org%water + frac_mixed * soil1(jj)%water(l)
         end do
      
-          !! sand, silt and clay are % so divide by tillage depth
-          mix_clay = mix_clay / dtil
-          mix_silt = mix_silt / dtil
-          mix_sand = mix_sand / dtil
-
           do l = 1, soil(jj)%nly
-            
             ! reconstitute each soil layer 
             frac_non_mixed = sol_msn(l) / sol_mass(l)
             
@@ -187,6 +197,9 @@
             soil(jj)%phys(l)%clay = frac_non_mixed * soil(jj)%phys(l)%clay + frac_mixed * mix_clay
             soil(jj)%phys(l)%silt = frac_non_mixed * soil(jj)%phys(l)%silt + frac_mixed * mix_silt
             soil(jj)%phys(l)%sand = frac_non_mixed * soil(jj)%phys(l)%sand + frac_mixed * mix_sand
+            soil(jj)%phys(l)%st = frac_non_mixed * soil(jj)%phys(l)%st + frac_mixed * mix_sw
+            soil(jj)%phys(l)%bd = frac_non_mixed * soil(jj)%phys(l)%bd + frac_mixed * mix_bd
+            soil(jj)%phys(l)%rock = frac_non_mixed * soil(jj)%phys(l)%rock + frac_mixed * mix_rock
 
             !do k = 1, npmx
             !  cs_soil(jj)%ly(l)%pest(k) = cs_soil(jj)%ly(l)%pest(k) * frac_non_mixed + smix(20+k) * frac_dep(l)

--- a/src/output_landscape_module.f90
+++ b/src/output_landscape_module.f90
@@ -1822,6 +1822,10 @@
         hru3%rhum = hru1%rhum + hru2%rhum
         hru3%solrad = hru1%solrad + hru2%solrad
         hru3%phubase0 = hru1%phubase0 + hru2%phubase0
+        hru3%lai_max = hru1%lai_max + hru2%lai_max
+        hru3%bm_max = hru1%bm_max + hru2%bm_max
+        hru3%bm_grow = hru1%bm_grow + hru2%bm_grow
+        hru3%c_gro = hru1%c_gro + hru2%c_gro
       end function hruout_plantweather_add
 
       function hruout_waterbal_div (hru1,const) result (hru2)
@@ -2071,6 +2075,10 @@
         hru2%wndspd = hru1%wndspd
         hru2%rhum = hru1%rhum
         hru2%phubase0 = hru1%phubase0
+        hru2%lai_max = hru1%lai_max
+        hru2%bm_max = hru1%bm_max
+        hru2%bm_grow = hru1%bm_grow
+        hru2%c_gro = hru1%c_gro
       end function hruout_plantweather_div
                   
       function hruout_plantweather_ave (hru1,const) result (hru2)
@@ -2098,6 +2106,10 @@
         hru2%rhum = hru1%rhum / const
         hru2%solrad = hru1%solrad / const
         hru2%phubase0 = hru1%phubase0 / const
+        hru2%lai_max = hru1%lai_max / const
+        hru2%bm_max = hru1%bm_max / const
+        hru2%bm_grow = hru1%bm_grow / const
+        hru2%c_gro = hru1%c_gro / const
       end function hruout_plantweather_ave
                           
       function hruout_plantweather_mult (hru1,const) result (hru2)
@@ -2125,6 +2137,10 @@
         hru2%wndspd = hru1%wndspd * const
         hru2%rhum = hru1%rhum * const
         hru2%phubase0 = hru1%phubase0 * const
+        hru2%lai_max = hru1%lai_max * const
+        hru2%bm_max = hru1%bm_max * const
+        hru2%bm_grow = hru1%bm_grow * const
+        hru2%c_gro = hru1%c_gro * const
       end function hruout_plantweather_mult
                           
                             

--- a/src/pest_apply.f90
+++ b/src/pest_apply.f90
@@ -3,26 +3,6 @@
 !!    ~ ~ ~ PURPOSE ~ ~ ~
 !!    this subroutine applies pesticide
 
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name         |units            |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    ap_ef(:)     |none             |application efficiency (0-1)
-!!    drift(:)     |kg               |amount of pesticide drifting onto main 
-!!                                   |channel in subbasin
-!!    hru_km(:)    |km**2            |area of HRU in square kilometers
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-
-!!    ~ ~ ~ OUTGOING VARIABLES ~ ~ ~
-!!    name        |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    drift(:)    |kg            |amount of pesticide drifting onto main 
-!!                               |channel in subbasin
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    ~ ~ ~ SUBROUTINES/FUNCTIONS CALLED ~ ~ ~
-!!    SWAT: Erfc
-
-!!    ~ ~ ~ ~ ~ ~ END SPECIFICATIONS ~ ~ ~ ~ ~ ~
-
       use mgt_operations_module
       use basin_module
       use soil_module

--- a/src/pest_decay.f90
+++ b/src/pest_decay.f90
@@ -4,15 +4,6 @@
 !!    this subroutine calculates degradation of pesticide in the soil and on 
 !!    the plants
 
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name          |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    decay_f(:)    |none          |exponential of the rate constant for
-!!                                 |degradation of the pesticide on foliage
-!!    decay_s(:)    |none          |exponential of the rate constant for
-!!                                 |degradation of the pesticide in soil
-!!    ihru          |none          |HRU number
-
       use pesticide_data_module
       use hru_module, only : ihru
       use constituent_mass_module
@@ -23,12 +14,12 @@
       implicit none 
       
       integer :: j = 0           !none     |hru number
-      integer :: k = 0           !none     |sequential pesticide number being simulated
+      integer :: k = 0           !none     |seqential pesticide number being simulated
       integer :: ipl = 0         !none     |plant number
       integer :: ipest_db = 0    !none     |pesticide number from pesticide data base
       integer :: l = 0           !none     |layer number
       integer :: ipseq = 0       !none     |sequential basin pesticide number
-      integer :: ipdb = 0        !none     |sequential pesticide number of daughter pesticide
+      integer :: ipdb = 0        !none     |seqential pesticide number of daughter pesticide
       integer :: imeta = 0       !none     |pesticide metabolite counter
       real :: mol_wt_rto = 0.    !ratio    |molecular weight ratio of duaghter to parent pesticide
       real :: pest_init = 0.     !kg/ha    |amount of pesticide present at beginning of day
@@ -50,7 +41,7 @@
           !! calculate degradation in soil
           do l = 1, soil(j)%nly
             pest_init = cs_soil(j)%ly(l)%pest(k)
-            if (pest_init > 1.e-12) then
+            if (pest_init > 0.) then
               pest_end = pest_init * pestcp(ipest_db)%decay_s
               cs_soil(j)%ly(l)%pest(k) = pest_end
               pst_decay = (pest_init - pest_end)
@@ -72,7 +63,7 @@
           !! adjust foliar pesticide for wash off
           do ipl = 1, pcom(j)%npl
             pest_init = cs_pl(j)%pl_on(ipl)%pest(k)
-            if (pest_init > 1.e-12) then
+            if (pest_init > 0.) then
               pest_end = pest_init * pestcp(ipest_db)%decay_f
               cs_pl(j)%pl_on(ipl)%pest(k) = pest_end
               hpestb_d(j)%pest(k)%decay_f = pest_init - pest_end

--- a/src/pest_decay.f90
+++ b/src/pest_decay.f90
@@ -14,12 +14,12 @@
       implicit none 
       
       integer :: j = 0           !none     |hru number
-      integer :: k = 0           !none     |seqential pesticide number being simulated
+      integer :: k = 0           !none     |sequential pesticide number being simulated
       integer :: ipl = 0         !none     |plant number
       integer :: ipest_db = 0    !none     |pesticide number from pesticide data base
       integer :: l = 0           !none     |layer number
       integer :: ipseq = 0       !none     |sequential basin pesticide number
-      integer :: ipdb = 0        !none     |seqential pesticide number of daughter pesticide
+      integer :: ipdb = 0        !none     |sequential pesticide number of daughter pesticide
       integer :: imeta = 0       !none     |pesticide metabolite counter
       real :: mol_wt_rto = 0.    !ratio    |molecular weight ratio of duaghter to parent pesticide
       real :: pest_init = 0.     !kg/ha    |amount of pesticide present at beginning of day

--- a/src/pest_enrsb.f90
+++ b/src/pest_enrsb.f90
@@ -4,20 +4,6 @@
 !!    this subroutine calculates the enrichment ratio for nutrient and
 !!    pesticide transport with runoff
 
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name        |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    surfq(:)    |mm H2O        |surface runoff generated on day in HRU
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-
-!!    ~ ~ ~ OUTGOING VARIABLES ~ ~ ~
-!!    name        |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    enratio     |none          |enrichment ratio
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    ~ ~ ~ ~ ~ ~ END SPECIFICATIONS ~ ~ ~ ~ ~ ~
-
       use hru_module, only : hru, surfq, sedyld, sanyld, silyld, clayld, sagyld, lagyld, ihru, enratio
       
       implicit none       

--- a/src/pest_lch.f90
+++ b/src/pest_lch.f90
@@ -5,26 +5,6 @@
 !!    pesticide transported with lateral subsurface flow, and pesticide
 !!    transported with surface runoff
 
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name         |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    ihru         |none          |HRU number
-!!    surfq(:)     |mm H2O        |surface runoff generated on day in HRU
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-
-!!    ~ ~ ~ OUTGOING VARIABLES ~ ~ ~
-!!    name         |units         |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    lat_pst(:)   |kg pst/ha     |amount of pesticide in lateral flow in HRU
-!!                                |for the day
-!!    zdb(:,:)     |
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ 
-
-!!    ~ ~ ~ SUBROUTINES/FUNCTIONS CALLED ~ ~ ~
-!!    Intrinsic: Exp, Min
-
-!!    ~ ~ ~ ~ ~ ~ END SPECIFICATIONS ~ ~ ~ ~ ~ ~
-
       use pesticide_data_module
       use basin_module
       use hru_module, only : hru, surfq, qtile, ihru

--- a/src/pest_pesty.f90
+++ b/src/pest_pesty.f90
@@ -3,15 +3,6 @@
 !!    ~ ~ ~ PURPOSE ~ ~ ~
 !!    this subroutine calculates pesticide transported with suspended sediment 
 
-!!    ~ ~ ~ INCOMING VARIABLES ~ ~ ~
-!!    name          |units        |definition
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-!!    enratio       |none         |enrichment ratio calculated for day in HRU
-!!    ihru          |none         |HRU number
-!!    pst_enr(:,:)  |none         |pesticide enrichment ratio
-!!    zdb(:,:)      |mm           |division term from net pesticide equation
-!!    ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-
       use hru_module, only : hru, sedyld, ihru, enratio
       use soil_module
       use constituent_mass_module

--- a/src/pest_washp.f90
+++ b/src/pest_washp.f90
@@ -27,7 +27,7 @@
         ipest_db = cs_db%pest_num(k)
         !! adjust foliar pesticide for wash off
         do ipl = 1, pcom(j)%npl
-          if (cs_pl(j)%pl_on(ipl)%pest(k) >= 0.0001) then
+          if (cs_pl(j)%pl_on(ipl)%pest(k) >= 0.) then
             if (ipest_db > 0) then
               pest_soil = pestdb(ipest_db)%washoff * cs_pl(j)%pl_on(ipl)%pest(k)
               if (pest_soil > cs_pl(j)%pl_on(ipl)%pest(k)) pest_soil = cs_pl(j)%pl_on(ipl)%pest(k)

--- a/src/pl_biomass_gro.f90
+++ b/src/pl_biomass_gro.f90
@@ -12,6 +12,7 @@
       use constituent_mass_module !rtb salt
       use salt_module, only : salt_uptake_on
       use salt_data_module, only : salt_effect
+      use output_landscape_module
       
       implicit none 
       
@@ -140,6 +141,8 @@
 
           pl_mass_up%m = bioday * pcom(j)%plstr(ipl)%reg
           pl_mass_up%c = 0.42 * bioday * pcom(j)%plstr(ipl)%reg
+          hpw_d(j)%bm_grow = pl_mass_up%m
+          hpw_d(j)%c_gro = pl_mass_up%c
                 
           !! increase in plant c
           if (bsn_cc%cswat == 2) then

--- a/src/wallo_demand.f90
+++ b/src/wallo_demand.f90
@@ -17,6 +17,7 @@
 
       !! zero total demand for each object
       wallod_out(iwallo)%dmd(idmd)%dmd_tot = 0.
+      trans_m3 = 0.
       
       !! compute total demand from each demand object
       select case (wallo(iwallo)%dmd(idmd)%ob_typ)


### PR DESCRIPTION
aqu_1d_control: Adjusted pesticide threshold check to use 0 instead of 1.e-12  .
cal_conditions.f90: commented out exit in 'cal_group' conditions
cbn_zhang2.f90: remove tillage_data_module and debug‐only import, ac.tivate sat calculation, introduce and initialize bmix_depth, replace hard‑coded bmix_eff with hru(j)%hyd%biomix in tillage mixing logic, and clean up stale commented code.
ch_rtpest.90 removed old purpose statement.
mgt_newtillmix.f90: Extend mgt_newtillmix to include moisture, bulk density and rock: declare and zero mix_sw, mix_bd, mix_rock; accumulate soil(jj)%phys(l)%st, bd, rock (alongside sand/silt/clay) in the mixing loop; and reapply mixed st, bd, rock to each layer during reconstitution.
output_landscape_module.f90: Extend  module functions to handle new biomass & canopy fields; lai_max, bm_max, bm_grow and c_gro components in all four element‑wise routines (add, div, ave, mult).
pest_apply.f90: removed old purpose statement.
pest_decay.f90: removed old purpose statement; Adjusted pest_init threshold check to use 0 instead of 1.e-12 if (pest_init > 1.e-12)
pest_enrsb.f90: removed old purpose statement.
pest_lch.f90: removed old purpose statement.
pest_pesty.f90: removed old purpose statement.
pest_washp.f90: Adjusted cs_pl(j)%pl_on(ipl)%pest(k) threshold check to use 0 instead of  0.0001.
pl_biomass_gro.f90: added output_landscape_module; capture pl_mass_up%m and pl_mass_up%c into hpw_d(j)%bm_grow and hpw_d(j)%c_gro in pl_biomass_gro.
wallo_demand.f90: Initialize trans_m3 as 0 before demand computation.

