### PR TITLE
Merge 0424

### DIFF
--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -6,6 +6,7 @@
         use organic_mineral_mass_module
         use carbon_module
         use output_landscape_module
+	use tillage_data_module
         use time_module, only : time
         
         implicit none
@@ -103,7 +104,7 @@
        real :: lslncat = 0    !                     |
        real :: min_n = 0      !                     |
        integer :: cf_lyr         !                     |which layer of coefs to use in carbon_coef.cbn
-       real :: bmix_depth     !mm                   !depth of biological
+       !real :: bmix_depth     !mm                   !depth of biological
        real :: soil_lyr_thickness !mm
        real :: sol_mass = 0.     !                     |
        real :: sol_min_n = 0.    !                     |
@@ -249,7 +250,7 @@
        cpn5 = 0.
        wmin = 0.
        dmdn = 0.
-       bmix_depth = 50    
+       !bmix_depth = 50    
        soil_lyr_thickness = 0
 
        j = ihru
@@ -309,7 +310,7 @@
           !!compute soil water factor - sut
           fc = soil(j)%phys(k)%fc + soil(j)%phys(k)%wpmm        ! units mm
           wc = soil(j)%phys(k)%st + soil(j)%phys(k)%wpmm        ! units mm
-          sat = soil(j)%phys(k)%ul + soil(j)%phys(k)%wpmm       ! units mm
+          !sat = soil(j)%phys(k)%ul + soil(j)%phys(k)%wpmm       ! units mm
           ! void = soil(j)%phys(k)%por * (1. - wc / sat)          ! fraction
 
           if (wc - soil(j)%phys(k)%wpmm < 0.) then
@@ -351,7 +352,8 @@
               else
                 ! Changed by fg to always have some bio mixing
                 if (soil(j)%phys(k)%d <= bmix_depth) then            
-                  org_con%till_eff = 1.0 + hru(j)%hyd%biomix
+                  ! org_con%till_eff = 1.0 + hru(j)%hyd%biomix
+                  org_con%till_eff = 1.0 + bmix_eff
                 else
 
                   if (k == 1) then
@@ -361,7 +363,7 @@
                   end if
 
                   if (soil(j)%phys(k)%d > bmix_depth .and. soil(j)%phys(k-1)%d < bmix_depth) then 
-                    org_con%till_eff = 1.0 + (hru(j)%hyd%biomix * (bmix_depth - soil(j)%phys(k-1)%d) / soil_lyr_thickness)  
+                    org_con%till_eff = 1.0 + (bmix_eff * (bmix_depth - soil(j)%phys(k-1)%d) / soil_lyr_thickness)  
                   else
                     org_con%till_eff = 1.0
                   end if
@@ -721,7 +723,7 @@
 	            lscta = min(soil1(j)%str(k)%c, lscta)              
               lslcta = min(soil1(j)%lig(k)%c, lslcta)
               
-              org_flux%co2fstr = .3 * lslcta
+              !org_flux%co2fstr = .3 * lslcta
               org_flux%co2fstr = org_allo(cf_lyr)%a1co2 * lslncta
               
               org_flux%cfstrs1 = a1 * lslncta

--- a/src/mgt_newtillmix.f90
+++ b/src/mgt_newtillmix.f90
@@ -48,10 +48,10 @@
       real :: dtil = 0.                !mm             |depth of mixing
       real :: frac_mixed = 0.          !               |
       real :: frac_non_mixed = 0.      !               |
-      real :: sol_mass(soil(jj)%nly)    !              |mass of the soil layer
-      real :: sol_msm(soil(jj)%nly)     !              |sol_mass mixed
-      real :: sol_msn(soil(jj)%nly)     !              |sol_mass not mixed 
-      real :: frac_dep(soil(jj)%nly)    !              |fraction of soil layer in tillage depth
+      real :: sol_mass(5)    !              |mass of the soil layer
+      real :: sol_msm(5)     !              |sol_mass mixed
+      real :: sol_msn(5)     !              |sol_mass not mixed 
+      real :: frac_dep(5)    !              |fraction of soil layer in tillage depth
       real :: frac1 = 0.
       real :: frac2 = 0.
       real :: mix_clay
@@ -131,7 +131,6 @@
         ! added by Armen 09/10/2010 next line only
         if (dtil < 10.0) dtil = 11.0
         do l = 1, soil(jj)%nly
-
           if (soil(jj)%phys(l)%d <= dtil) then
             !! msm = mass of soil mixed for the layer
             !! msn = mass of soil not mixed for the layer       
@@ -154,9 +153,9 @@
           mix_sw = mix_sw + frac_mixed * soil(jj)%phys(l)%st
           mix_bd = mix_bd + frac_mixed * soil(jj)%phys(l)%bd
           mix_rock = mix_rock + frac_mixed * soil(jj)%phys(l)%rock
-          mix_sand = mix_sand + frac_mixed * soil(jj)%phys(l)%sand
-          mix_silt = mix_silt + frac_mixed * soil(jj)%phys(l)%silt
-          mix_clay = mix_clay + frac_mixed * soil(jj)%phys(l)%clay
+          mix_sand = mix_sand + frac_mixed * soil(jj)%phys(l)%sand * sol_mass(l) / 100.
+          mix_silt = mix_silt + frac_mixed * soil(jj)%phys(l)%silt * sol_mass(l) / 100.
+          mix_clay = mix_clay + frac_mixed * soil(jj)%phys(l)%clay * sol_mass(l) / 100.
           
           mix_mn = mix_mn + frac_mixed * soil1(jj)%mn(l)
           mix_mp = mix_mp + frac_mixed * soil1(jj)%mp(l)
@@ -177,6 +176,7 @@
           do l = 1, soil(jj)%nly
             ! reconstitute each soil layer 
             frac_non_mixed = sol_msn(l) / sol_mass(l)
+            frac_mixed = 1. - frac_non_mixed
             
             soil1(jj)%mn(l) = frac_non_mixed * soil1(jj)%mn(l) + frac_dep(l) * mix_mn
             ! print*, "in mgt_newtill_mix", l, soil1(jj)%mn(l)%no3
@@ -194,12 +194,16 @@
             soil1(jj)%man(l) = frac_non_mixed * soil1(jj)%man(l) + frac_dep(l) * mix_org%man
             soil1(jj)%water(l) = frac_non_mixed * soil1(jj)%water(l) + frac_dep(l) * mix_org%water
             
-            soil(jj)%phys(l)%clay = frac_non_mixed * soil(jj)%phys(l)%clay + frac_mixed * mix_clay
-            soil(jj)%phys(l)%silt = frac_non_mixed * soil(jj)%phys(l)%silt + frac_mixed * mix_silt
-            soil(jj)%phys(l)%sand = frac_non_mixed * soil(jj)%phys(l)%sand + frac_mixed * mix_sand
-            soil(jj)%phys(l)%st = frac_non_mixed * soil(jj)%phys(l)%st + frac_mixed * mix_sw
-            soil(jj)%phys(l)%bd = frac_non_mixed * soil(jj)%phys(l)%bd + frac_mixed * mix_bd
-            soil(jj)%phys(l)%rock = frac_non_mixed * soil(jj)%phys(l)%rock + frac_mixed * mix_rock
+            soil(jj)%phys(l)%clay = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%clay * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_clay)
+            soil(jj)%phys(l)%silt = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%silt * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_silt)
+            soil(jj)%phys(l)%sand = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%sand * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_sand)
+            soil(jj)%phys(l)%rock = 100. / sol_mass(l) * (frac_non_mixed * soil(jj)%phys(l)%rock * sol_mass(l) / 100. &
+                                                                                             + frac_dep(l) * mix_rock)
+            soil(jj)%phys(l)%st = frac_non_mixed * soil(jj)%phys(l)%st + frac_dep(l) * mix_sw
+            !soil(jj)%phys(l)%bd = frac_non_mixed * soil(jj)%phys(l)%bd + frac_dep(l) * mix_bd
 
             !do k = 1, npmx
             !  cs_soil(jj)%ly(l)%pest(k) = cs_soil(jj)%ly(l)%pest(k) * frac_non_mixed + smix(20+k) * frac_dep(l)

--- a/src/mgt_newtillmix.f90
+++ b/src/mgt_newtillmix.f90
@@ -48,10 +48,10 @@
       real :: dtil = 0.                !mm             |depth of mixing
       real :: frac_mixed = 0.          !               |
       real :: frac_non_mixed = 0.      !               |
-      real :: sol_mass(5)    !              |mass of the soil layer
-      real :: sol_msm(5)     !              |sol_mass mixed
-      real :: sol_msn(5)     !              |sol_mass not mixed 
-      real :: frac_dep(5)    !              |fraction of soil layer in tillage depth
+      real :: sol_mass(15)    !              |mass of the soil layer
+      real :: sol_msm(15)     !              |sol_mass mixed
+      real :: sol_msn(15)     !              |sol_mass not mixed 
+      real :: frac_dep(15)    !              |fraction of soil layer in tillage depth
       real :: frac1 = 0.
       real :: frac2 = 0.
       real :: mix_clay


### PR DESCRIPTION
mgt_newtillmix.f90:
Dimension Adjustment: Changed sol_mass, sol_msm, sol_msn, and frac_dep arrays to use a fixed size of 15 instead of dynamically depending on soil(jj)%nly.... which wasn't working as intended
Normalization Updates: Incorporated sol_mass normalization for soil property calculations such as mix_sand, mix_silt, and mix_clay.
Added Complementary Variable: Explicitly calculated frac_mixed as 1. - frac_non_mixed.
Refactored Soil Property Updates: Updated logic for soil(jj)%phys(l) properties to include normalization by sol_mass and frac_dep.

cbn_zhang2.f90:
Reverted some changes that had overwritten past commit.