### PR TITLE
NAM SRC updates 05272025

### DIFF
--- a/src/actions.f90
+++ b/src/actions.f90
@@ -288,6 +288,31 @@
               if (iac > 1) pcom(j)%dtbl(idtbl)%days_act(iac-1) =  0     !reset previous action day counter
             end if
 
+          !manure application
+          case ("manure")
+            j = d_tbl%act(iac)%ob_num
+            if (j == 0) j = ob_cur
+            
+            if (pcom(j)%dtbl(idtbl)%num_actions(iac) <= Int(d_tbl%act(iac)%const2)) then
+              ipl = 1
+              ifrt = d_tbl%act_typ(iac)               !fertilizer type from fert data base
+              frt_kg = d_tbl%act(iac)%const           !amount applied in kg/ha
+              ifertop = d_tbl%act_app(iac)            !surface application fraction from chem app data base
+
+              call pl_manure (ifrt, frt_kg, ifertop)
+              call salt_fert(j,ifrt,frt_kg,ifertop) !rtb salt 
+              call cs_fert(j,ifrt,frt_kg,ifertop) !rtb cs
+              if (pco%mgtout == "y") then
+                write (2612,*) j, time%yrc, time%mo, time%day_mo, mgt%op_char, " MANURE ", &
+                  phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, pl_mass(j)%tot(ipl)%m,           &
+                  soil1(j)%rsd(1)%m, sol_sumno3(j), sol_sumsolp(j), frt_kg, fertno3, fertnh3,         &
+                  fertorgn, fertsolp, fertorgp
+              endif
+              pcom(j)%dtbl(idtbl)%num_actions(iac) = pcom(j)%dtbl(idtbl)%num_actions(iac) + 1
+              pcom(j)%dtbl(idtbl)%days_act(iac) = 1     !reset days since last action
+              if (iac > 1) pcom(j)%dtbl(idtbl)%days_act(iac-1) =  0     !reset previous action day counter
+            end if
+
           !future fertilizer
           case ("fert_future")
             j = ob_cur
@@ -1082,13 +1107,13 @@
             if (pcom(j)%dtbl(idtbl)%num_actions(iac) <= Int(d_tbl%act(iac)%const2)) then
               cn2(j) = chg_par (cn2(j), d_tbl%act(iac)%option, d_tbl%act(iac)%const, 35., 95.)
               call curno (cn2(j), j)
-            end if
+              if (pco%mgtout == "y") then
+                ipl = 1
+                write (2612, *) j, time%yrc, time%mo, time%day_mo, d_tbl%act(iac)%name, "    CNUP", phubase(j),    &
+                  pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, pl_mass(j)%tot(ipl)%m, soil1(j)%rsd(1)%m,       &
+                  sol_sumno3(j), sol_sumsolp(j), cn_prev, cn2(j)
+              end if
             
-            if (pco%mgtout == "y") then
-              ipl = 1
-              write (2612, *) j, time%yrc, time%mo, time%day_mo, d_tbl%act(iac)%name, "    CNUP", phubase(j),    &
-                pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, pl_mass(j)%tot(ipl)%m, soil1(j)%rsd(1)%m,       &
-                sol_sumno3(j), sol_sumsolp(j), cn_prev, cn2(j)
             end if
             
             pcom(j)%dtbl(idtbl)%num_actions(iac) = pcom(j)%dtbl(idtbl)%num_actions(iac) + 1

--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -98,13 +98,13 @@
        integer :: j = 0          !                     |number of hru
        integer :: k = 0          !none                 |counte
        integer :: kk = 0         !                     |
-       integer :: lmnta = 0      !                     |      
+       real :: lmnta = 0      !                     |      
        real :: min_n_ppm = 0  !                     |
-       integer :: lslncat = 0    !                     |
+       real :: lslncat = 0    !                     |
        real :: min_n = 0      !                     |
        integer :: cf_lyr         !                     |hich layer of coefs to use in carbon_coef.cbn
-       integer :: bmix_depth     !mm                   !depth of biological
-       integer :: soil_lyr_thickness !mm
+       real :: bmix_depth     !mm                   !depth of biological
+       real :: soil_lyr_thickness !mm
        real :: sol_mass = 0.     !                     |
        real :: sol_min_n = 0.    !                     |
        real :: fc = 0.           !mm H2O               |amount of water available to plants in soil layer at field capacity (fc - wp),Index:(layer,HRU)

--- a/src/command.f90
+++ b/src/command.f90
@@ -334,9 +334,10 @@
               end select
               
               rec_d(irec) = ob(icmd)%hd(1)
-
-              if(cs_db%num_salts > 0) call recall_salt(irec) !rtb salt
-              if(cs_db%num_cs > 0) call recall_cs(irec) !rtb cs
+              
+              if (cs_db%num_tot > 0) obcs(icmd)%hd(1) = hin_csz
+              if (cs_db%num_salts > 0) call recall_salt(irec) !rtb salt
+              if (cs_db%num_cs > 0) call recall_cs(irec) !rtb cs
               
           !case ("exco")   ! export coefficient hyds are set at start
 

--- a/src/mgt_sched.f90
+++ b/src/mgt_sched.f90
@@ -343,8 +343,21 @@
                   fertorgn, fertsolp, fertorgp
               endif
             endif
-            
 
+          case ("manu")   !! fertilizer operation
+            ipl = 1
+            ifrt = mgt%op1                          !fertilizer type from fert data base
+            frt_kg = mgt%op3                        !amount applied in kg/ha
+            ifertop = mgt%op4                       !surface application fraction from chem app data base
+              call pl_manure (ifrt, frt_kg, ifertop)
+              call salt_fert(j,ifrt,frt_kg,ifertop) !rtb salt 
+              call cs_fert(j,ifrt,frt_kg,ifertop) !rtb cs
+              if (pco%mgtout == "y") then
+                write (2612,*) j, time%yrc, time%mo, time%day_mo, mgt%op_char, " MANURE ", &
+                  phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, pl_mass(j)%tot(ipl)%m,           &
+                  soil1(j)%rsd(1)%m, sol_sumno3(j), sol_sumsolp(j), frt_kg, fertno3, fertnh3,         &
+                  fertorgn, fertsolp, fertorgp
+              endif    
  
           case ("pest")   !! pesticide operation
             !xwalk application in the mgt file with the pest community
@@ -488,7 +501,6 @@
                   sol_sumno3(j), sol_sumsolp(j), irrig(j)%applied, irrig(j)%runoff
             end if
 
-            
           case ("pudl")    !! Puddling operation Jaehak 2022
             !! xwalk with puddling ops names
             do ipdl = 1, db_mx%pudl_db

--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -130,7 +130,7 @@
           soil1(j)%str(l) = soil1(j)%str(l) + pool_fr * org_frt
           
           !! add lignin manure pool
-          ! soil1(j)%str(l) = soil1(j)%str(l) + 0.8 * soil1(j)%str(l)
+          soil1(j)%lig(l) = soil1(j)%lig(l) + 0.175 * pool_fr * org_frt
           
           !! total residue pool is metabolic + structural
           soil1(j)%rsd(l) = soil1(j)%meta(l) + soil1(j)%str(l)

--- a/src/pl_manure.f90
+++ b/src/pl_manure.f90
@@ -103,7 +103,7 @@
                         frt_kg * fertdb(ifrt)%forgn
         
           !orgc_f is the fraction of organic carbon in fertilizer - assume 0.42
-          orgc_f = 0.42 * frt_kg
+          orgc_f = 0.42
           !X1 is fertlizer applied to layer (kg/ha)
           !xx is fraction of fertilizer applied to layer
           X1 = xx * frt_kg 

--- a/src/read_mgtops.f90
+++ b/src/read_mgtops.f90
@@ -112,6 +112,22 @@
             endif
           end do
 
+        case ("manu")
+          !xwalk fert name with fertilizer data base
+          do idb = 1, db_mx%fertparm
+            if (sched(isched)%mgt_ops(iop)%op_char == fertdb(idb)%fertnm) then
+              sched(isched)%mgt_ops(iop)%op1 = idb
+              exit
+            endif
+          end do
+          !xwalk application type with chemical application data base
+          do idb = 1, db_mx%chemapp_db
+            if (sched(isched)%mgt_ops(iop)%op_plant == chemapp_db(idb)%name) then
+              sched(isched)%mgt_ops(iop)%op4 = idb
+              exit
+            endif
+          end do
+
         case ("pest")
           !xwalk fert name with fertilizer data base
           do idb = 1, db_mx%pestparm

--- a/src/res_control.f90
+++ b/src/res_control.f90
@@ -27,7 +27,8 @@
       real :: alpha_down = 0.
 
       ht1 = ob(icmd)%hin    !! set incoming flow
-      ht2 = resz            !! zero outgoing flow
+      ht2 = resz            !! zero outgoing flow, sediment and nutrients
+      hcs2 = hin_csz        !! zero outgoing constituents
 
       if (time%yrc > res_hyd(jres)%iyres .or. (time%mo >= res_hyd(jres)%mores   &
                                    .and. time%yrc == res_hyd(jres)%iyres)) then
@@ -178,14 +179,8 @@
       else
         !! reservoir has not been constructed yet
         ob(icmd)%hd(1) = ob(icmd)%hin
+        if (cs_db%num_tot > 0) obcs(icmd)%hd(1) = obcs(icmd)%hin(1)
       end if
 
-  !!!! for Luis only    
-      !if (jres == 1) then
-      !  write (7777,*) time%day, time%yrc, jres, res(jres)%flo, ht1%flo, ht2%flo,   &
-      !                                           res(jres)%sed, ht1%sed, ht2%sed
-      !end if
-  !!!! for Luis only
-      
       return
       end subroutine res_control

--- a/src/res_read.f90
+++ b/src/res_read.f90
@@ -71,7 +71,7 @@
          if (eof < 0) exit
        end do
        
-       do ires = 1, db_mx%res_dat
+       do ires = 1, sp_ob%res
         !! initialize organics and minerals in water
         do isp_ini = 1, db_mx%res_init
           if (res_dat_c(ires)%init == res_init_dat_c(isp_ini)%init) then

--- a/src/sd_channel_control3.f90
+++ b/src/sd_channel_control3.f90
@@ -120,7 +120,8 @@
       ht1 = ob(icmd)%hin
       
       !! zero outgoing flow and sediment - ht2
-      ht2 = hz 
+      ht2 = hz
+      obcs(icmd)%hd(:) = hin_csz
       
       !! zero daily in/out morphology and sediment budget output
       ch_sed_bud(ich) = ch_sed_budz


### PR DESCRIPTION
This pull request introduces several changes across multiple Fortran files, focusing on adding new functionality for manure management, improving nutrient and sediment handling, and refining variable types for better precision. Below is a categorized summary of the most important changes:

### Manure Management Enhancements:
* Added a new case `"manure"` in `subroutine actions` to handle manure application, including logic for updating fertilizer type, amount, and application fraction, as well as writing management outputs. (`src/actions.f90`, [src/actions.f90R291-R315](diffhunk://#diff-8234d6a985e886d5e4e126a9589f27f9293df591e7a28dba9d675a12ac465739R291-R315))
* Introduced a new case `"manu"` in `subroutine mgt_sched` for manure-related operations, with calls to handle manure application and associated outputs. (`src/mgt_sched.f90`, [src/mgt_sched.f90L347-R360](diffhunk://#diff-9a5de63db0b3e60b92ee69e07811b2520115adf2b1abf694760ee134597e4ffdL347-R360))
* Updated `subroutine read_mgtops` to map manure operations (`"manu"`) with fertilizer and chemical application databases. (`src/read_mgtops.f90`, [src/read_mgtops.f90R115-R130](diffhunk://#diff-506e930fc7f16430359eb47415bdf5efdfd9a6f45238b9b6e97ed7c18d0abde8R115-R130))

### Nutrient and Sediment Handling:
* Modified `subroutine res_control` to initialize outgoing constituents (`hcs2`) for reservoirs and handle nutrient flow when reservoirs are not yet constructed. (`src/res_control.f90`, [[1]](diffhunk://#diff-93e7a5cef78f9dce0be570564699394e4e5bf9e517e23a83f846370b7a774560L30-R31) [[2]](diffhunk://#diff-93e7a5cef78f9dce0be570564699394e4e5bf9e517e23a83f846370b7a774560R182-L189)
* Updated `subroutine sd_channel_control3` to zero out outgoing constituents (`obcs`) for sediment and nutrient management. (`src/sd_channel_control3.f90`, [src/sd_channel_control3.f90R124](diffhunk://#diff-1534ea6d15060bdc3f360dc13485adf68f432094b7a689bf73df60aad8063e0bR124))

### Code Precision Improvements:
* Changed several integer variables to real in `subroutine cbn_zhang2` for better precision in calculations, including `lmnta`, `lslncat`, `bmix_depth`, and `soil_lyr_thickness`. (`src/cbn_zhang2.f90`, [src/cbn_zhang2.f90L101-R107](diffhunk://#diff-30ff43cef9906554910d2b26f2bdb07203c47245cb50e39ffa69e2e78c00515eL101-R107))

### Other Updates:
* Adjusted manure lignin pool calculations in `subroutine pl_fert` to include a specific fraction of organic fertilizer. (`src/pl_fert.f90`, [src/pl_fert.f90L133-R133](diffhunk://#diff-9b0e1d4abb3e646ba86be7886b853114a0e7f0df5f3b359e9ec9358c88e5dd79L133-R133))
* Simplified the calculation of organic carbon fraction (`orgc_f`) in `subroutine pl_manure` to use a constant value. (`src/pl_manure.f90`, [src/pl_manure.f90L106-R106](diffhunk://#diff-8a974c52f31af53c2c18ffc312b06f35e6a8719604296fd678c0c5fbabbca4a2L106-R106))
* Updated reservoir initialization loop in `subroutine res_read` to iterate over `sp_ob%res` instead of `db_mx%res_dat`. (`src/res_read.f90`, [src/res_read.f90L74-R74](diffhunk://#diff-0ada63a6706efe905b2f52a909e36e56821f02ed2dd48dc5843e0b4973db7b3eL74-R74))

These changes collectively enhance the model's capabilities for manure management and nutrient tracking while improving code clarity and precision.