### PR TITLE
Alfa

### DIFF
--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -906,15 +906,7 @@
                 hrc_d(j)%rsd_rootdecay_c = lmcta + lscta
                 ! soil1(j)%rsd(k)%c = soil1(j)%rsd(k)%c - hrc_d(j)%rsd_rootdecay_c
               end if 
-              
-                soil1(j)%mn(k)%no3 = soil1(j)%mn(k)%no3 - (org_flux%immmets1 + org_flux%immstrs1 + org_flux%immstrs2 +    &
-                            org_flux%imms1s2 + org_flux%imms1s3 + org_flux%imms2s1 + org_flux%imms2s3 + org_flux%imms3s1)
-      
-                soil1(j)%mn(k)%nh4 = soil1(j)%mn(k)%nh4 + org_flux%mnrmets1 + org_flux%mnrstrs1 + org_flux%mnrstrs2 +     &
-                             org_flux%mnrs1s2 + org_flux%mnrs1s3 + org_flux%mnrs2s1 + org_flux%mnrs2s3 + org_flux%mnrs3s1
-                !hnb_d(j)%immob =
-                !hnb_d(j)%minrl =
-              
+                      
               if (soil1(j)%mn(k)%no3 < 0.0) soil1(j)%mn(k)%no3 = 0.0
               if (soil1(j)%mn(k)%nh4 < 0.0) soil1(j)%mn(k)%nh4 = 0.0
 

--- a/src/pl_grow.f90
+++ b/src/pl_grow.f90
@@ -22,9 +22,11 @@
         pl_mass_up = plt_mass_z
         
         !! check for start and end of dormancy of temp-based growth plant
-        idp = pcom(j)%plcur(ipl)%idplt
-        if (pldb(idp)%trig == "temp_gro") then
-          call pl_dormant
+        if (pcom(j)%plcur(ipl)%gro == "y") then
+            idp = pcom(j)%plcur(ipl)%idplt
+            if (pldb(idp)%trig == "temp_gro") then
+              call pl_dormant
+            end if
         end if
        
         !! plant will not undergo stress if dormant


### PR DESCRIPTION
This pull request includes updates to the Fortran codebase, specifically addressing logical corrections in two subroutines: `cbn_zhang2` and `pl_grow`. The changes improve the accuracy of soil nitrogen balance calculations and ensure proper handling of plant growth conditions.

### Soil nitrogen balance corrections:
* Removed outdated and redundant calculations for nitrate (`no3`) and ammonium (`nh4`) fluxes in `subroutine cbn_zhang2`. This simplifies the logic and ensures that negative values for `no3` and `nh4` are reset to zero without unnecessary intermediate steps. (`src/cbn_zhang2.f90`, [src/cbn_zhang2.f90L910-L917](diffhunk://#diff-30ff43cef9906554910d2b26f2bdb07203c47245cb50e39ffa69e2e78c00515eL910-L917))

### Plant growth logic improvements:
* Added a conditional check to ensure that temperature-based growth logic is only executed when the plant's growth status (`gro`) is active. This prevents unnecessary or incorrect calls to `pl_dormant` when the plant is not actively growing. (`src/pl_grow.f90`, [src/pl_grow.f90R25-R30](diffhunk://#diff-fadbfbbce32fa4bac827aea1305ae732547ae814a3dccc5d46a8c67044816782R25-R30))