### PR TITLE
Exposed hard coded values used in pl_fert.f90 and now can be input in the carb_coefs_cbn file.

### DIFF
--- a/data/Ames_sub1/carb_coefs.cbn
+++ b/data/Ames_sub1/carb_coefs.cbn
@@ -23,3 +23,7 @@ prmt_44         0.5
 
 # Length of days that a tillage event will be effective
 till_eff_days   30
+
+# Manure carbon coefficients
+#             rtof   man_to_c               
+manure_coef   0.5    0.42

--- a/src/carbon_coef_read.f90
+++ b/src/carbon_coef_read.f90
@@ -83,6 +83,9 @@ subroutine carbon_coef_read
                 case("till_eff_days")
                     backspace (107)
                     read (107,*,iostat=eof) var_name, till_eff_days
+                case("manure_coef")
+                    backspace (107)
+                    read (107,*,iostat=eof) var_name, man_coef%rtof, man_coef%man_to_c
                 case default
                     write(*, fmt="(a,a,a)", advance="yes") "Error: The variable ", var_name, "in the input file carb_coefs.cbn is not a recognized variable."
                     write(*, fmt="(a)") "       and cannot be processed."

--- a/src/carbon_module.f90
+++ b/src/carbon_module.f90
@@ -63,6 +63,14 @@
       type (carbon_inputs), dimension(2) :: carbdb 
       type (carbon_inputs) :: carbz  
       logical :: carbon_coef_file = .false. !           !set to true if carbon_coef.cbn file exits.
+
+      type manure_coef
+          real :: rtof = 0.5            !none          |weighting factor used to partition the 
+                                        !              |organic N & P concentration of septic effluent
+                                        !              |between the fresh organic and the stable organic pools
+          real :: man_to_c = 0.42       !              |conversion of manure solids to carbon
+      end type manure_coef
+      type (manure_coef) :: man_coef
       
       type organic_allocations
           ! real :: abl = 0.        !               |Fraction of microbial biomass loss due to leaching

--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -45,7 +45,7 @@
 
       j = ihru
       
-      rtof = 0.5
+      rtof = man_coef%rtof
       !! calculate c:n ratio for manure applications for SWAT-C
       if (bsn_cc%cswat == 2) then
         if (fertdb(ifrt)%forgn > 0. .or. fertdb(ifrt)%forgp > 0. ) then
@@ -54,7 +54,7 @@
         
         if (manure_flag) then
           org_frt%m = frt_kg
-          org_frt%c = 0.42 * frt_kg
+          org_frt%c = man_coef%man_to_c * frt_kg
           org_frt%n = fertdb(ifrt)%forgn * frt_kg
           org_frt%p = fertdb(ifrt)%forgp * frt_kg
           c_n_rto = .175 * org_frt%c / (fertdb(ifrt)%fminn + fertdb(ifrt)%forgn + 1.e-5)

--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -133,7 +133,7 @@
           soil1(j)%lig(l) = soil1(j)%lig(l) + 0.175 * pool_fr * org_frt
           
           !! total residue pool is metabolic + structural
-          soil1(j)%rsd(l) = soil1(j)%meta(l) + soil1(j)%str(l)
+          ! soil1(j)%rsd(l) = soil1(j)%meta(l) + soil1(j)%str(l)
           
         end if
         


### PR DESCRIPTION
Exposes two hard coded variables/values in pl_fert.f90.  One is the variable rtof which looks the fraction of carbon that goes to the slow humas pool and the other is a value of 0.42 that is the conversion of manure solids to carb.  Its now called man_to_c.  The variables can be changed in the carb_coefs.cbn file.  I have updated this file in the data ames input data.   If the carb_coefs.cbn file is missing or if those variables are missing in that file then it will default to the original values of 0.5 for rtof and 0.42 for manure solids to c conversion.