### PR TITLE
Nam branch

### DIFF
--- a/src/hyd_read_connect.f90
+++ b/src/hyd_read_connect.f90
@@ -100,7 +100,7 @@
                 end if
                 npaths = cs_db%num_paths
                 if (npaths > 0) then
-          allocate (obcs(i)%hin(1)%path(npaths), source = 0.)
+                  allocate (obcs(i)%hin(1)%path(npaths), source = 0.)
                   allocate (obcs(i)%hin_sur(1)%path(npaths), source = 0.)
                   allocate (obcs(i)%hin_lat(1)%path(npaths), source = 0.)
                   allocate (obcs(i)%hin_til(1)%path(npaths), source = 0.)

--- a/src/mgt_newtillmix.f90
+++ b/src/mgt_newtillmix.f90
@@ -184,9 +184,9 @@
             soil1(jj)%man(l) = frac_non_mixed * soil1(jj)%man(l) + frac_dep(l) * mix_org%man
             soil1(jj)%water(l) = frac_non_mixed * soil1(jj)%water(l) + frac_dep(l) * mix_org%water
             
-            soil(jj)%phys(l)%clay = frac_non_mixed * soil(jj)%phys(l)%clay + frac_mixed * mix_clay
-            soil(jj)%phys(l)%silt = frac_non_mixed * soil(jj)%phys(l)%silt + frac_mixed * mix_silt
-            soil(jj)%phys(l)%sand = frac_non_mixed * soil(jj)%phys(l)%sand + frac_mixed * mix_sand
+            !soil(jj)%phys(l)%clay = frac_non_mixed * soil(jj)%phys(l)%clay + frac_mixed * mix_clay
+            !soil(jj)%phys(l)%silt = frac_non_mixed * soil(jj)%phys(l)%silt + frac_mixed * mix_silt
+            !soil(jj)%phys(l)%sand = frac_non_mixed * soil(jj)%phys(l)%sand + frac_mixed * mix_sand
 
             !do k = 1, npmx
             !  cs_soil(jj)%ly(l)%pest(k) = cs_soil(jj)%ly(l)%pest(k) * frac_non_mixed + smix(20+k) * frac_dep(l)

--- a/src/sd_channel_sediment3.f90
+++ b/src/sd_channel_sediment3.f90
@@ -95,6 +95,7 @@
       
       !! compute flood plain deposition
       ave_rate = ht1%flo / 86400.     !m3/s
+      sd_ch(ich)%bankfull_flo = 2.
       bf_flow = sd_ch(ich)%bankfull_flo * ch_rcurv(ich)%elev(2)%flo_rate
       florate_ob = ave_rate - bf_flow
       if (florate_ob > 0.) then
@@ -112,7 +113,7 @@
         !trap_eff = 0.05 * log(sd_ch(ich)%fp_inun_days) + 0.1
         !! trap efficiency from Dynamic SedNet Component Model Reference Guide: Update 2017
         fp_m2 = 3. * sd_ch(ich)%chw * sd_ch(ich)%chl * 1000.
-        exp_co = 0.0003 * fp_m2 / florate_ob
+        exp_co = 0.0001 * fp_m2 / florate_ob
         trap_eff = sd_ch(ich)%fp_inun_days * (florate_ob / ave_rate) * (1. - exp(-exp_co))
         trap_eff = Min (1., trap_eff)
         fp_dep%sed = trap_eff * ht1%sed
@@ -178,7 +179,8 @@
       b_exp = min (3.5, b_exp)
       if (vel_rch > vel_cr) then
         !! bank erosion m/yr
-        ebank_m = 0.00024 * (vel_rch / vel_cr) ** sd_ch(ich)%bank_exp
+        ebank_m = 0.001 / (1. + exp(-4. * (vel_rch / vel_cr) / sd_ch(ich)%chw))
+        !ebank_m = 0.00024 * (vel_rch / vel_cr) ** sd_ch(ich)%bank_exp
       else
         ebank_m = 0.
       end if

--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -73,6 +73,7 @@
       real :: crop_yld_t_ha = 0.     !t/ha          |annual and ave annual basin crop yields
       real :: sw_init = 0.
       real :: sno_init = 0.
+      real :: bank_mm, bed_mm
       integer :: iob = 0             !              |
       integer :: curyr = 0           !              |
       integer :: mo = 0              !              |
@@ -366,13 +367,17 @@
       
       do ich = 1, sp_ob%chandeg
         !! write channel morphology - downcutting and widening
-        ch_morph(ich)%w_yr = ch_morph(ich)%w_yr / 1000. / sd_ch(ich)%chw / time%yrs_prt
+        bank_mm = ch_morph(ich)%w_yr 
+        bed_mm = ch_morph(ich)%d_yr
+        ch_morph(ich)%w_yr = ch_morph(ich)%w_yr / sd_ch(ich)%chw / time%yrs_prt
         ch_morph(ich)%d_yr = ch_morph(ich)%d_yr / sd_ch(ich)%chd / time%yrs_prt
+        !! mm = t / (3.*bd*w*l) -> assume fp width = 3*chw; len(m)=1000.*km; bd=t/m3; mm=1000.*m
         ch_morph(ich)%fp_mm = ch_morph(ich)%fp_mm / (3. * sd_ch(ich)%chw *           &
-                                         sd_ch(ich)%chl * 1000.) / time%yrs_prt
+                                                sd_ch(ich)%chl) / time%yrs_prt
         iob = sp_ob1%chandeg + ich - 1
-        write (7778,*) ich, ob(iob)%name, ob(iob)%area_ha, ch_morph(ich)%w_yr,       &
-                                           ch_morph(ich)%d_yr, ch_morph(ich)%fp_mm
+        write (7778,*) ich, ob(iob)%name, ob(iob)%area_ha, sd_ch(ich)%chw, bank_mm,  &
+                ch_morph(ich)%w_yr, sd_ch(ich)%chd, bed_mm, ch_morph(ich)%d_yr,      &
+                                                            ch_morph(ich)%fp_mm
       end do
       
       do ich = 1, sp_ob%res


### PR DESCRIPTION
This pull request includes updates to three Fortran source files, focusing on soil mixing, sediment transport, and time control calculations. The changes include code refactoring, parameter adjustments, and the addition of new variables for improved clarity and functionality.

### Soil Mixing Updates:
* Commented out calculations for soil physical properties (`clay`, `silt`, and `sand`) in the `mgt_newtillmix` subroutine. (`src/mgt_newtillmix.f90`, [src/mgt_newtillmix.f90L187-R189](diffhunk://#diff-7a4e9add7a6a66a7ab7d56218612b1ebf67aecb16507bbe61891b69135f2d613L187-R189))

### Sediment Transport Updates:
* Added a new variable `bankfull_flo` with a constant value of `2.0` in the `sd_channel_sediment3` subroutine to support bankfull flow calculations. (`src/sd_channel_sediment3.f90`, [src/sd_channel_sediment3.f90R98](diffhunk://#diff-e6eea0f3c15a6d8d0d9d1230753faa4fd38b6840a4fd978d62b86d413b93bc13R98))
* Adjusted the formula for `exp_co` in sediment trapping efficiency calculations, changing the coefficient from `0.0003` to `0.0001` for improved accuracy. (`src/sd_channel_sediment3.f90`, [src/sd_channel_sediment3.f90L115-R116](diffhunk://#diff-e6eea0f3c15a6d8d0d9d1230753faa4fd38b6840a4fd978d62b86d413b93bc13L115-R116))
* Replaced the formula for `ebank_m` (bank erosion rate) with a new logistic function for better modeling of erosion dynamics, while commenting out the old formula. (`src/sd_channel_sediment3.f90`, [src/sd_channel_sediment3.f90L181-R183](diffhunk://#diff-e6eea0f3c15a6d8d0d9d1230753faa4fd38b6840a4fd978d62b86d413b93bc13L181-R183))

### Time Control Updates:
* Introduced new variables `bank_mm` and `bed_mm` in the `time_control` subroutine to store intermediate values for channel morphology calculations. (`src/time_control.f90`, [src/time_control.f90R76](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dR76))
* Modified channel morphology output to include additional details such as `bank_mm` and `bed_mm` for enhanced reporting and clarity. (`src/time_control.f90`, [src/time_control.f90L369-R380](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL369-R380))