### PR TITLE
src updates 07092025

### DIFF
--- a/src/hru_control.f90
+++ b/src/hru_control.f90
@@ -821,6 +821,9 @@
       ! output_plantweather
         hpw_d(j)%lai = pcom(j)%lai_sum
         hpw_d(j)%bioms = pl_mass(j)%tot_com%m
+        if (pl_mass(j)%tot_com%m < 0.) then
+          pl_mass(j)%tot_com%m = 0.
+        end if
         hpw_d(j)%residue = soil1(j)%rsd(1)%m
         hpw_d(j)%yield = pl_yield%m
         pl_yield = plt_mass_z

--- a/src/pl_dormant.f90
+++ b/src/pl_dormant.f90
@@ -36,18 +36,11 @@
           !! add dead stem mass to residue pool
           rto = pldb(idp)%bm_dieoff
           stem_drop = rto * pl_mass(j)%stem(ipl)
-          !! drop lai to minimum if not already
+          !! lower lai by same ratio
           lai_init = pcom(j)%plg(ipl)%lai
-          pcom(j)%plg(ipl)%lai = pldb(idp)%alai_min
+          pcom(j)%plg(ipl)%lai = Max (pldb(idp)%alai_min, rto * lai_init)
           !! compute leaf biomass drop
-          if (lai_init > 0.001) then
-            lai_drop = (lai_init - pcom(j)%plg(ipl)%lai) / lai_init
-          else
-            lai_drop = 0.
-          end if
-          lai_drop = max (0., lai_drop)
-          lai_drop = amin1 (1., lai_drop)
-          leaf_drop%m = rto * lai_drop * pl_mass(j)%leaf(ipl)%m
+          leaf_drop%m = rto * pl_mass(j)%leaf(ipl)%m
           leaf_drop%n = leaf_drop%m * pcom(j)%plm(ipl)%n_fr
           leaf_drop%n = max (0., leaf_drop%n)
           leaf_drop%p = leaf_drop%m * pcom(j)%plm(ipl)%p_fr
@@ -58,6 +51,9 @@
 
           !! add all seed/fruit mass to residue pool
           pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - abgr_drop
+        if (pl_mass(j)%tot_com%m < 0.) then
+          pl_mass(j)%tot_com%m = 0.
+        end if
           pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - abgr_drop
           pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - stem_drop
           pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - leaf_drop

--- a/src/pl_graze.f90
+++ b/src/pl_graze.f90
@@ -52,40 +52,26 @@
         !! later we can add preferences - by animal type or simply by n and p content
         eat_plant =  graze%eat / pl_mass(j)%ab_gr_com%m
         eat_plant = amin1 (eat_plant, 1.)
-        eat_seed = eat_plant * pl_mass(j)%seed(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        eat_leaf = eat_plant * pl_mass(j)%leaf(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        eat_stem = eat_plant * pl_mass(j)%stem(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        graz_plant = eat_plant * pl_mass(j)%ab_gr(ipl)
-        graz_seed = eat_seed * pl_mass(j)%seed(ipl)
-        graz_leaf = eat_leaf * pl_mass(j)%leaf(ipl)
-        graz_stem = eat_stem * pl_mass(j)%stem(ipl)
         
         !! remove biomass and organics from plant pools
         !! update remaining plant organic pools
-        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - graz_seed
-        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - graz_leaf
-        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - graz_stem
-        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - graz_plant
-        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - graz_plant
+        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - eat_plant * pl_mass(j)%seed(ipl)
+        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - eat_plant * pl_mass(j)%leaf(ipl)
+        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - eat_plant * pl_mass(j)%stem(ipl)
+        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - eat_plant * pl_mass(j)%ab_gr(ipl)
+        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - eat_plant * pl_mass(j)%ab_gr(ipl)
 
         !! remove biomass trampled - assume evenly divided by biomass of plant
         tramp_plant = graze%tramp / pl_mass(j)%ab_gr_com%m
         tramp_plant = amin1 (tramp_plant, 1.)
-        tramp_seed = tramp_plant * pl_mass(j)%seed(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        tramp_leaf = tramp_plant * pl_mass(j)%leaf(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        tramp_stem = tramp_plant * pl_mass(j)%stem(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        graz_plant = tramp_plant * pl_mass(j)%ab_gr(ipl)
-        graz_seed = tramp_seed * pl_mass(j)%seed(ipl)
-        graz_leaf = tramp_leaf * pl_mass(j)%leaf(ipl)
-        graz_stem = tramp_stem * pl_mass(j)%stem(ipl)
         
         !! remove biomass and organics from plant pools
         !! update remaining plant organic pools
-        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - graz_seed
-        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - graz_leaf
-        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - graz_stem
-        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - graz_plant
-        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - graz_plant
+        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - tramp_plant * pl_mass(j)%seed(ipl)
+        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - tramp_plant * pl_mass(j)%leaf(ipl)
+        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - tramp_plant * pl_mass(j)%stem(ipl)
+        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - tramp_plant * pl_mass(j)%ab_gr(ipl)
+        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - tramp_plant * pl_mass(j)%ab_gr(ipl)
 
         !! reset leaf area index and fraction of growing season
         if (dmi > 1.) then

--- a/src/pl_mortality.f90
+++ b/src/pl_mortality.f90
@@ -20,12 +20,12 @@
       j = ihru
       idp = pcom(j)%plcur(ipl)%idplt
       
-      !keep biomass below maximum - excess to residue (need to include c, n and p adjustments)
-      bm_dieoff = (1. + pldb(idp)%bm_dieoff) * (pl_mass(j)%ab_gr(ipl)%m - (pldb(idp)%bmx_peren * 1000.))  !t/ha -> kg/ha
+      !! keep biomass below maximum - 5% more than excess - excess to residue
+      bm_dieoff = 1.05 * (pl_mass(j)%ab_gr(ipl)%m - (pldb(idp)%bmx_peren * 1000.))  !t/ha -> kg/ha
       if (bm_dieoff > 1.e-6 .and. pl_mass(j)%ab_gr(ipl)%m > bm_dieoff) then
           
         !! partition all plant components by above ground ratio
-        rto = bm_dieoff / pl_mass(j)%ab_gr(ipl)%m
+        rto = 1. - (bm_dieoff / pl_mass(j)%ab_gr(ipl)%m)
         rto = amin1 (1., rto)
         pl_mass(j)%tot(ipl) = rto * pl_mass(j)%tot(ipl)
         pl_mass(j)%ab_gr(ipl) = rto * pl_mass(j)%ab_gr(ipl)
@@ -38,8 +38,9 @@
         rto1 = 1. - rto
         rto1 = max (0., rto1)
         
-      !! add above ground biomass to surface residue pools
+        !! add above ground die off biomass to surface residue pools
         soil1(j)%rsd(1) = soil1(j)%rsd(1) + rto1 * pl_mass(j)%ab_gr(ipl)
+        
         if (bsn_cc%cswat == 2) then
           soil1(j)%meta(1) = soil1(j)%meta(1) + 0.85 * rto1 * pl_mass(j)%ab_gr(ipl)
           soil1(j)%str(1) = soil1(j)%str(1) + 0.15 * rto1 * pl_mass(j)%ab_gr(ipl)


### PR DESCRIPTION
This pull request focuses on improving the robustness and accuracy of biomass calculations across several subroutines in the Fortran codebase. The changes include ensuring non-negative biomass values, simplifying calculations, and refining logic for plant biomass adjustments in various scenarios such as dormancy, grazing, and mortality.

### Robustness Improvements:
* Added checks to ensure that `pl_mass(j)%tot_com%m` does not fall below zero in `subroutine hru_control` and `subroutine pl_dormant` to prevent invalid negative biomass values. [[1]](diffhunk://#diff-98d017aee2f97704b9e5c35356a2ec3893354dd4371e673a409af900e75d20a8R824-R826) [[2]](diffhunk://#diff-efa17505433dede12b78a46ae255446d1502642043d83c589ef55a2cd55358ddR54-R56)

### Simplification of Calculations:
* Simplified the calculation of leaf biomass drop in `subroutine pl_dormant` by directly applying the ratio `rto` to the leaf biomass instead of using intermediate variables and conditions.
* Streamlined grazing and trampling biomass adjustments in `subroutine pl_graze` by consolidating calculations into a single step for each plant component.

### Refinements in Biomass Adjustments:
* Adjusted the formula for biomass die-off in `subroutine pl_mortality` to include a 5% buffer above the maximum biomass threshold and refined the partitioning logic for above-ground biomass.
* Clarified and updated comments in `subroutine pl_mortality` to explicitly indicate that above-ground die-off biomass is added to surface residue pools.