### PR TITLE
Main copy

### DIFF
--- a/src/hru_control.f90
+++ b/src/hru_control.f90
@@ -823,6 +823,9 @@
       ! output_plantweather
         hpw_d(j)%lai = pcom(j)%lai_sum
         hpw_d(j)%bioms = pl_mass(j)%tot_com%m
+        if (pl_mass(j)%tot_com%m < 0.) then
+          pl_mass(j)%tot_com%m = 0.
+        end if
         hpw_d(j)%residue = soil1(j)%rsd(1)%m
         hpw_d(j)%yield = pl_yield%m
         pl_yield = plt_mass_z

--- a/src/hyd_read_connect.f90
+++ b/src/hyd_read_connect.f90
@@ -100,7 +100,7 @@
                 end if
                 npaths = cs_db%num_paths
                 if (npaths > 0) then
-          allocate (obcs(i)%hin(1)%path(npaths), source = 0.)
+                  allocate (obcs(i)%hin(1)%path(npaths), source = 0.)
                   allocate (obcs(i)%hin_sur(1)%path(npaths), source = 0.)
                   allocate (obcs(i)%hin_lat(1)%path(npaths), source = 0.)
                   allocate (obcs(i)%hin_til(1)%path(npaths), source = 0.)

--- a/src/pl_dormant.f90
+++ b/src/pl_dormant.f90
@@ -35,18 +35,11 @@
           !! add dead stem mass to residue pool
           rto = pldb(idp)%bm_dieoff
           stem_drop = rto * pl_mass(j)%stem(ipl)
-          !! drop lai to minimum if not already
+          !! lower lai by same ratio
           lai_init = pcom(j)%plg(ipl)%lai
-          pcom(j)%plg(ipl)%lai = pldb(idp)%alai_min
+          pcom(j)%plg(ipl)%lai = Max (pldb(idp)%alai_min, rto * lai_init)
           !! compute leaf biomass drop
-          if (lai_init > 0.001) then
-            lai_drop = (lai_init - pcom(j)%plg(ipl)%lai) / lai_init
-          else
-            lai_drop = 0.
-          end if
-          lai_drop = max (0., lai_drop)
-          lai_drop = amin1 (1., lai_drop)
-          leaf_drop%m = rto * lai_drop * pl_mass(j)%leaf(ipl)%m
+          leaf_drop%m = rto * pl_mass(j)%leaf(ipl)%m
           leaf_drop%n = leaf_drop%m * pcom(j)%plm(ipl)%n_fr
           leaf_drop%n = max (0., leaf_drop%n)
           leaf_drop%p = leaf_drop%m * pcom(j)%plm(ipl)%p_fr
@@ -57,6 +50,9 @@
 
           !! add all seed/fruit mass to residue pool
           pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - abgr_drop
+        if (pl_mass(j)%tot_com%m < 0.) then
+          pl_mass(j)%tot_com%m = 0.
+        end if
           pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - abgr_drop
           pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - stem_drop
           pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - leaf_drop

--- a/src/pl_graze.f90
+++ b/src/pl_graze.f90
@@ -52,40 +52,26 @@
         !! later we can add preferences - by animal type or simply by n and p content
         eat_plant =  graze%eat / pl_mass(j)%ab_gr_com%m
         eat_plant = amin1 (eat_plant, 1.)
-        eat_seed = eat_plant * pl_mass(j)%seed(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        eat_leaf = eat_plant * pl_mass(j)%leaf(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        eat_stem = eat_plant * pl_mass(j)%stem(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        graz_plant = eat_plant * pl_mass(j)%ab_gr(ipl)
-        graz_seed = eat_seed * pl_mass(j)%seed(ipl)
-        graz_leaf = eat_leaf * pl_mass(j)%leaf(ipl)
-        graz_stem = eat_stem * pl_mass(j)%stem(ipl)
         
         !! remove biomass and organics from plant pools
         !! update remaining plant organic pools
-        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - graz_seed
-        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - graz_leaf
-        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - graz_stem
-        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - graz_plant
-        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - graz_plant
+        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - eat_plant * pl_mass(j)%seed(ipl)
+        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - eat_plant * pl_mass(j)%leaf(ipl)
+        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - eat_plant * pl_mass(j)%stem(ipl)
+        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - eat_plant * pl_mass(j)%ab_gr(ipl)
+        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - eat_plant * pl_mass(j)%ab_gr(ipl)
 
         !! remove biomass trampled - assume evenly divided by biomass of plant
         tramp_plant = graze%tramp / pl_mass(j)%ab_gr_com%m
         tramp_plant = amin1 (tramp_plant, 1.)
-        tramp_seed = tramp_plant * pl_mass(j)%seed(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        tramp_leaf = tramp_plant * pl_mass(j)%leaf(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        tramp_stem = tramp_plant * pl_mass(j)%stem(ipl)%m / pl_mass(j)%ab_gr(ipl)%m
-        graz_plant = tramp_plant * pl_mass(j)%ab_gr(ipl)
-        graz_seed = tramp_seed * pl_mass(j)%seed(ipl)
-        graz_leaf = tramp_leaf * pl_mass(j)%leaf(ipl)
-        graz_stem = tramp_stem * pl_mass(j)%stem(ipl)
         
         !! remove biomass and organics from plant pools
         !! update remaining plant organic pools
-        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - graz_seed
-        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - graz_leaf
-        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - graz_stem
-        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - graz_plant
-        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - graz_plant
+        pl_mass(j)%seed(ipl) = pl_mass(j)%seed(ipl) - tramp_plant * pl_mass(j)%seed(ipl)
+        pl_mass(j)%leaf(ipl) = pl_mass(j)%leaf(ipl) - tramp_plant * pl_mass(j)%leaf(ipl)
+        pl_mass(j)%stem(ipl) = pl_mass(j)%stem(ipl) - tramp_plant * pl_mass(j)%stem(ipl)
+        pl_mass(j)%tot(ipl) = pl_mass(j)%tot(ipl) - tramp_plant * pl_mass(j)%ab_gr(ipl)
+        pl_mass(j)%ab_gr(ipl) = pl_mass(j)%ab_gr(ipl) - tramp_plant * pl_mass(j)%ab_gr(ipl)
 
         !! reset leaf area index and fraction of growing season
         if (dmi > 1.) then

--- a/src/pl_mortality.f90
+++ b/src/pl_mortality.f90
@@ -20,12 +20,14 @@
       j = ihru
       idp = pcom(j)%plcur(ipl)%idplt
       
-      !keep biomass below maximum - excess to residue (need to include c, n and p adjustments)
-      bm_dieoff = (1. + pldb(idp)%bm_dieoff) * (pl_mass(j)%ab_gr(ipl)%m - (pldb(idp)%bmx_peren * 1000.))  !t/ha -> kg/ha
+      !! keep biomass below maximum - 5% more than excess - excess to residue
+      bm_dieoff = 1.05 * (pl_mass(j)%ab_gr(ipl)%m - (pldb(idp)%bmx_peren * 1000.))  !t/ha -> kg/ha
       if (bm_dieoff > 1.e-6 .and. pl_mass(j)%ab_gr(ipl)%m > bm_dieoff) then
           
         !! partition all plant components by above ground ratio
+
         rto = bm_dieoff / pl_mass(j)%ab_gr(ipl)%m  ! Fraction of dead biomass
+
         rto = amin1 (1., rto)
       
         !! add dead material to residue

--- a/src/pl_mortality.f90
+++ b/src/pl_mortality.f90
@@ -19,17 +19,17 @@
                
       j = ihru
       idp = pcom(j)%plcur(ipl)%idplt
-      
-      !! keep biomass below maximum - 5% more than excess - excess to residue
-      bm_dieoff = 1.05 * (pl_mass(j)%ab_gr(ipl)%m - (pldb(idp)%bmx_peren * 1000.))  !t/ha -> kg/ha
+
+      !keep biomass below maximum - excess to residue (need to include c, n and p adjustments)
+      bm_dieoff = (1. + pldb(idp)%bm_dieoff) * (pl_mass(j)%ab_gr(ipl)%m - (pldb(idp)%bmx_peren * 1000.))  !t/ha -> kg/ha
       if (bm_dieoff > 1.e-6 .and. pl_mass(j)%ab_gr(ipl)%m > bm_dieoff) then
-          
+
         !! partition all plant components by above ground ratio
 
         rto = bm_dieoff / pl_mass(j)%ab_gr(ipl)%m  ! Fraction of dead biomass
 
         rto = amin1 (1., rto)
-      
+
         !! add dead material to residue
         rto1 = 1. - rto  ! Fraction remaining of living biomass
         rto1 = max (0., rto1)

--- a/src/res_control.f90
+++ b/src/res_control.f90
@@ -27,9 +27,7 @@
       real :: alpha_down = 0.
 
       ht1 = ob(icmd)%hin    !! set incoming flow
-
       ht2 = resz            !! zero outgoing flow, sediment and nutrients
-
       hcs2 = hin_csz        !! zero outgoing constituents
 
       if (time%yrc > res_hyd(jres)%iyres .or. (time%mo >= res_hyd(jres)%mores   &

--- a/src/res_control.f90
+++ b/src/res_control.f90
@@ -27,7 +27,9 @@
       real :: alpha_down = 0.
 
       ht1 = ob(icmd)%hin    !! set incoming flow
-      ht2 = resz            !! zero outgoing flow
+
+      ht2 = resz            !! zero outgoing flow, sediment and nutrients
+
       hcs2 = hin_csz        !! zero outgoing constituents
 
       if (time%yrc > res_hyd(jres)%iyres .or. (time%mo >= res_hyd(jres)%mores   &
@@ -182,6 +184,7 @@
         if (cs_db%num_tot > 0) obcs(icmd)%hd(1) = obcs(icmd)%hin(1)
       end if
 
-      
+
+
       return
       end subroutine res_control

--- a/src/sd_channel_sediment3.f90
+++ b/src/sd_channel_sediment3.f90
@@ -95,6 +95,7 @@
       
       !! compute flood plain deposition
       ave_rate = ht1%flo / 86400.     !m3/s
+      sd_ch(ich)%bankfull_flo = 2.
       bf_flow = sd_ch(ich)%bankfull_flo * ch_rcurv(ich)%elev(2)%flo_rate
       florate_ob = ave_rate - bf_flow
       if (florate_ob > 0.) then
@@ -112,7 +113,7 @@
         !trap_eff = 0.05 * log(sd_ch(ich)%fp_inun_days) + 0.1
         !! trap efficiency from Dynamic SedNet Component Model Reference Guide: Update 2017
         fp_m2 = 3. * sd_ch(ich)%chw * sd_ch(ich)%chl * 1000.
-        exp_co = 0.0003 * fp_m2 / florate_ob
+        exp_co = 0.0001 * fp_m2 / florate_ob
         trap_eff = sd_ch(ich)%fp_inun_days * (florate_ob / ave_rate) * (1. - exp(-exp_co))
         trap_eff = Min (1., trap_eff)
         fp_dep%sed = trap_eff * ht1%sed
@@ -177,7 +178,8 @@
       b_exp = min (3.5, b_exp)
       if (vel_rch > vel_cr) then
         !! bank erosion m/yr
-        ebank_m = 0.00024 * (vel_rch / vel_cr) ** sd_ch(ich)%bank_exp
+        ebank_m = 0.001 / (1. + exp(-4. * (vel_rch / vel_cr) / sd_ch(ich)%chw))
+        !ebank_m = 0.00024 * (vel_rch / vel_cr) ** sd_ch(ich)%bank_exp
       else
         ebank_m = 0.
       end if

--- a/src/sd_channel_sediment3.f90
+++ b/src/sd_channel_sediment3.f90
@@ -1,4 +1,4 @@
-      subroutine sd_channel_sediment3
+            subroutine sd_channel_sediment3
 
       use climate_module
       use sd_channel_module
@@ -8,9 +8,9 @@
       use hru_module, only : hru
       use water_body_module
       use reservoir_module
-    
+
       implicit none     
-    
+
       integer :: iob = 0            !               |object number
       integer :: ihru = 0
       integer :: iihru = 0
@@ -54,10 +54,10 @@
       real :: wet_fill = 0.
       real :: ave_rate
       !!
-      
+
       ich = isdch
       iob = sp_ob1%chandeg + jrch - 1
-      
+
       ebtm_m = 0.
       ebank_m = 0.
       ebtm_t = 0.
@@ -68,14 +68,14 @@
       bed_ero = hz 
       ch_trans = hz
       ch_wat_d(ich)%precip = 0.
-      
+
       !! calculate channel sed and nutrient processes if inflow > 0
       if (ht1%flo > 1.e-6) then
-      
+
       !! calculate peak daily flow
       pk_rto = sd_ch(ich)%pk_rto * (1. + 2.66 * (ob(icmd)%area_ha / 100.) ** (-.3))
       peakrate = pk_rto * ht1%flo / 86400.     !m3/s
-        
+
       !! interpolate rating curve using peak rate
       call rcurv_interp_flo (ich, peakrate)
       !! use peakrate as flow rate
@@ -83,7 +83,7 @@
       vel = h_rad ** .6666 * Sqrt(sd_ch(ich)%chs) / (sd_ch(ich)%chn + .001)
       vel = peakrate / rcurv%xsec_area
       rttime = sd_ch(ich)%chl / (3.6 * vel)
-                
+
       !! add precip to inflow - km * m * 1000 m/km * ha/10000 m2 = ha
       ch_wat_d(ich)%area_ha = sd_ch(ich)%chl * sd_ch(ich)%chw / 10.
       !! m3 = 10. * mm * ha
@@ -92,10 +92,10 @@
       rto = precip / ht1%flo
       ob(icmd)%tsin(:) = (1. + rto) * ob(icmd)%tsin(:)
       ht1%flo = ht1%flo + precip
-      
+
       !! compute flood plain deposition
       ave_rate = ht1%flo / 86400.     !m3/s
-      sd_ch(ich)%bankfull_flo = 2.
+
       bf_flow = sd_ch(ich)%bankfull_flo * ch_rcurv(ich)%elev(2)%flo_rate
       florate_ob = ave_rate - bf_flow
       if (florate_ob > 0.) then
@@ -113,20 +113,20 @@
         !trap_eff = 0.05 * log(sd_ch(ich)%fp_inun_days) + 0.1
         !! trap efficiency from Dynamic SedNet Component Model Reference Guide: Update 2017
         fp_m2 = 3. * sd_ch(ich)%chw * sd_ch(ich)%chl * 1000.
-        exp_co = 0.0001 * fp_m2 / florate_ob
+        exp_co = 0.0003 * fp_m2 / florate_ob
         trap_eff = sd_ch(ich)%fp_inun_days * (florate_ob / ave_rate) * (1. - exp(-exp_co))
         trap_eff = Min (1., trap_eff)
         fp_dep%sed = trap_eff * ht1%sed
-        
+
         !! deposit Particulate P and N in the floodplain
         fp_dep%orgn = trap_eff * sd_ch(ich)%n_dep_enr * ht1%orgn
         fp_dep%sedp = trap_eff * sd_ch(ich)%p_dep_enr * ht1%sedp
         !! trap nitrate and sol P in flood plain - when not simulating flood plain interactions?
         fp_dep%no3 = 0.         !trap_eff * ht1%no3
         fp_dep%solp = 0.        !trap_eff * ht1%solp
-        
+
         ht1 = ht1 - fp_dep
-        
+
         !! if flood plain link - fill wetlands to emergency
         do ihru = 1, sd_ch(ich)%fp%hru_tot
           iihru = sd_ch(ich)%fp%hru(ihru)
@@ -152,12 +152,12 @@
             end if
           end if
         end do
-            
+
       end if     ! florate_ob > 0.
-      
+
       !! add sediment deposition to calculate mm of deposition over the flood plain later
       ch_morph(ich)%fp_mm = ch_morph(ich)%fp_mm + fp_dep%sed
-      
+
       !! calc bank erosion
       cohesion = (-87.1 + (42.82 * sd_ch(ich)%ch_clay) - (0.261 * sd_ch(ich)%ch_clay ** 2.) &
                                      + (0.029 * sd_ch(ich)%ch_clay ** 3.))
@@ -168,7 +168,7 @@
       vel_cr = log10 (2200. * sd_ch(ich)%chd) * (0.0004 * (bd_fac + cohes_fac)) ** 0.5
       !sd_ch(ich)%vcr_coef = 1.
       vel_cr = sd_ch(ich)%vcr_coef * vel_cr
-      
+
       !! calculate radius of curvature
       rad_curv = ((12. * sd_ch(ich)%chw) * sd_ch(ich)%sinu ** 1.5) /               &
                                             (13. * (sd_ch(ich)%sinu -1.) ** 0.5)
@@ -178,12 +178,12 @@
       b_exp = min (3.5, b_exp)
       if (vel_rch > vel_cr) then
         !! bank erosion m/yr
-        ebank_m = 0.001 / (1. + exp(-4. * (vel_rch / vel_cr) / sd_ch(ich)%chw))
-        !ebank_m = 0.00024 * (vel_rch / vel_cr) ** sd_ch(ich)%bank_exp
+        ebank_m = 0.00024 * (vel_rch / vel_cr) ** sd_ch(ich)%bank_exp
+
       else
         ebank_m = 0.
       end if
-      
+
       !! write for Peter
       !if (ich == 2133) then
       !write () time%day, time%yrc, ich, sd_ch(ich)%chw, sd_ch(ich)%chw, sd_ch(ich)%chl,   &
@@ -191,7 +191,7 @@
       !    sd_ch(ich)%ch_clay, cohesion, sd_ch(ich)%cov, veg, cohes_fac, sd_ch(ich)%ch_bd, &
       !    bd_fac, sd_ch(ich)%vcr_coef, vel_cr, sd_ch(ich)%bank_exp, ebank_m, "  0.24 ")
       !end if
-      
+
       ch_morph(ich)%w_yr = ch_morph(ich)%w_yr + ebank_m
 
       !! mass of sediment eroded -> t = 1000 * bankcut (mm) * depth (m) * lengthcut (m) * bd (t/m3)
@@ -211,7 +211,7 @@
       rto = bank_ero%flo / ht1%flo
       ob(icmd)%tsin(:) = (1. - rto) * ob(icmd)%tsin(:)
       ht1 = ht1 + bank_ero
-      
+
       !! calculate channel deposition based on fall velocity - SWRRB book
       !! assume particle size = 0.03 mm -- median silt size
       !vel_fall = 411. * sd_ch(ich)%part_size ** 2     ! m/h
@@ -260,7 +260,7 @@
       rto = bed_ero%flo / ht1%flo
       !ob(icmd)%tsin(:) = (1. - rto) * ob(icmd)%tsin(:)
       !ht1 = ht1 + bed_ero
-      
+
       end if        ! inflow>0
 
       return

--- a/src/swr_origtile.f90
+++ b/src/swr_origtile.f90
@@ -20,7 +20,11 @@
         sw_excess = (tile_above_btm / wt_shall) * (soil(j)%sw - soil(j)%sumfc)
         !! (wt_above_btm - tile_above_btm) / wt_above_btm * (sw - fc)
         sw_excess = (wt_shall - tile_above_btm) / wt_shall * (soil(j)%sw - soil(j)%sumfc)
-        qtile = sw_excess * (1. - Exp(-24. / hru(j)%sdr%time))
+        if (hru(j)%sdr%time < 1.) then
+          qtile = sw_excess
+        else
+          qtile = sw_excess * (1. - Exp(-24. / hru(j)%sdr%time))
+        end if
         qtile = Min(qtile, hru(j)%sdr%drain_co)
       else
         qtile = 0.

--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -73,6 +73,7 @@
       real :: crop_yld_t_ha = 0.     !t/ha          |annual and ave annual basin crop yields
       real :: sw_init = 0.
       real :: sno_init = 0.
+      real :: bank_mm, bed_mm
       integer :: iob = 0             !              |
       integer :: curyr = 0           !              |
       integer :: mo = 0              !              |
@@ -372,13 +373,17 @@
       
       do ich = 1, sp_ob%chandeg
         !! write channel morphology - downcutting and widening
-        ch_morph(ich)%w_yr = ch_morph(ich)%w_yr / 1000. / sd_ch(ich)%chw / time%yrs_prt
+        bank_mm = ch_morph(ich)%w_yr 
+        bed_mm = ch_morph(ich)%d_yr
+        ch_morph(ich)%w_yr = ch_morph(ich)%w_yr / sd_ch(ich)%chw / time%yrs_prt
         ch_morph(ich)%d_yr = ch_morph(ich)%d_yr / sd_ch(ich)%chd / time%yrs_prt
+        !! mm = t / (3.*bd*w*l) -> assume fp width = 3*chw; len(m)=1000.*km; bd=t/m3; mm=1000.*m
         ch_morph(ich)%fp_mm = ch_morph(ich)%fp_mm / (3. * sd_ch(ich)%chw *           &
-                                         sd_ch(ich)%chl * 1000.) / time%yrs_prt
+                                                sd_ch(ich)%chl) / time%yrs_prt
         iob = sp_ob1%chandeg + ich - 1
-        write (7778,*) ich, ob(iob)%name, ob(iob)%area_ha, ch_morph(ich)%w_yr,       &
-                                           ch_morph(ich)%d_yr, ch_morph(ich)%fp_mm
+        write (7778,*) ich, ob(iob)%name, ob(iob)%area_ha, sd_ch(ich)%chw, bank_mm,  &
+                ch_morph(ich)%w_yr, sd_ch(ich)%chd, bed_mm, ch_morph(ich)%d_yr,      &
+                                                            ch_morph(ich)%fp_mm
       end do
       
       do ich = 1, sp_ob%res


### PR DESCRIPTION
This pull request includes multiple updates to improve the handling of plant mass, sediment, and hydrological processes in the Fortran codebase. The changes primarily focus on ensuring numerical stability, simplifying calculations, and adding new variables for better reporting.

### Plant mass handling and stability improvements:
* Added checks to prevent negative values in `pl_mass(j)%tot_com%m` in `subroutine hru_control` and `subroutine pl_dormant`. This ensures plant mass does not drop below zero during calculations. [[1]](diffhunk://#diff-98d017aee2f97704b9e5c35356a2ec3893354dd4371e673a409af900e75d20a8R826-R828) [[2]](diffhunk://#diff-efa17505433dede12b78a46ae255446d1502642043d83c589ef55a2cd55358ddR53-R55)
* Simplified the calculation of leaf biomass drop in `subroutine pl_dormant` by removing redundant conditional logic and directly scaling by the ratio of biomass die-off.
* Refactored grazing and trampling calculations in `subroutine pl_graze` to directly scale plant components by the fraction grazed or trampled, reducing redundant variables and improving clarity.

### Sediment and hydrology updates:
* Added new variables `bank_mm` and `bed_mm` in `subroutine time_control` to separately track bank and bed sediment changes for improved reporting. Adjusted output to include these new metrics. [[1]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dR76) [[2]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL375-R386)
* Updated comments in `subroutine res_control` to clarify the handling of outgoing flow, sediment, and nutrients.

### Minor improvements and cleanup:
* Removed redundant blank lines in `subroutine res_control` and `subroutine sd_channel_sediment3` for better readability. [[1]](diffhunk://#diff-93e7a5cef78f9dce0be570564699394e4e5bf9e517e23a83f846370b7a774560R186) [[2]](diffhunk://#diff-e6eea0f3c15a6d8d0d9d1230753faa4fd38b6840a4fd978d62b86d413b93bc13R182)
* Added conditional logic in `subroutine swr_origtile` to handle cases where `hru(j)%sdr%time` is less than 1, ensuring proper calculation of `qtile`.