### PR TITLE
Update conditional_module.f90

### DIFF
--- a/src/conditional_module.f90
+++ b/src/conditional_module.f90
@@ -26,7 +26,7 @@
       end type actions_var
        
       type decision_table
-        character (len=25) :: name = ""                                 ! name of the decision table
+        character (len=40) :: name = ""                                 ! name of the decision table
         integer :: conds = 0                                            ! number of conditions
         integer :: alts = 0                                             ! number of alternatives
         integer :: acts = 0                                             ! number of actions


### PR DESCRIPTION
This pull request makes a small change to the `decision_table` type in the `conditional_module` module, extending the length of the `name` field from 25 to 40 characters to allow for longer names.

* [`src/conditional_module.f90`](diffhunk://#diff-67bc0682259cd408958f0604aa9b65d31e4b225c452af559aff5da070aaff8a4L29-R29): Updated the `name` field in the `decision_table` type to have a maximum length of 40 characters instead of 25.