### PR TITLE
Burn fix 07232025

### DIFF
--- a/src/actions.f90
+++ b/src/actions.f90
@@ -1088,11 +1088,14 @@
             if (j == 0) j = ob_cur
             
             if (pcom(j)%dtbl(idtbl)%num_actions(iac) <= Int(d_tbl%act(iac)%const2)) then
-              iburn = d_tbl%act_typ(iac)           !burn type from fire data base
+              iburn = d_tbl%act_typ(iac)           !burn type
               do ipl = 1, pcom(j)%npl
                 call pl_burnop (j, iburn)
               end do
                         
+
+              ! reset plant index for output after burn operation
+              ipl = 1
               if (pco%mgtout == "y") then
                 write (2612, *) j, time%yrc, time%mo, time%day_mo, d_tbl%act(iac)%name, "    BURN", phubase(j),    &
                     pcom(j)%plcur(ipl)%phuacc, soil(j)%sw,pl_mass(j)%tot(ipl)%m, soil1(j)%rsd(1)%m,   &

--- a/src/mgt_sched.f90
+++ b/src/mgt_sched.f90
@@ -309,7 +309,7 @@
             irrig(j)%applied = irrop_db(irrop)%amt_mm * irrop_db(irrop)%eff * (1. - irrop_db(irrop)%surq)
             irrig(j)%runoff = irrop_db(irrop)%amt_mm * irrop_db(irrop)%surq
             pcom(j)%days_irr = 1            ! reset days since last irrigation
-
+      
             ! add irrigation to yearly sum for dtbl conditioning jga6-25
             hru(j)%irr_yr = hru(j)%irr_yr + irrig(j)%applied
             
@@ -411,16 +411,16 @@
             endif
  
           case ("burn")   !! burning
-            iburn = mgt%op1                 !burn type from fire data base
-            do ipl = 1, pcom(j)%npl
-              call pl_burnop (j, iburn)
+            iburn = mgt%op1   ! burn type from fire database
+            call pl_burnop(j, iburn)
 
-              if (pco%mgtout == "y") then
-                write (2612, *) j, time%yrc, time%mo, time%day_mo, mgt%op_char, "    BURN ", phubase(j),   &
+            if (pco%mgtout == "y") then
+                do ipl = 1, pcom(j)%npl
+                    write (2612, *) j, time%yrc, time%mo, time%day_mo, mgt%op_char, "    BURN ", phubase(j),   &
                     pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, pl_mass(j)%tot(ipl)%m, soil1(j)%rsd(1)%m,      &
                     sol_sumno3(j), sol_sumsolp(j)
-              end if
-            end do
+                end do
+            end if
 
           case ("swep")   !! street sweeping (only if iurban=2)
             ipl = Max(1, mgt%op2)


### PR DESCRIPTION
This pull request includes updates to the burn operation logic in two subroutines, improving clarity and ensuring proper handling of plant indices during operations. The changes focus on resetting indices and adjusting loops for output consistency.

### Updates to burn operation logic:

* `src/actions.f90` (`subroutine actions`): Added a reset for the plant index (`ipl = 1`) after the burn operation to ensure proper output handling. Updated the comment for `iburn` to improve clarity.

* `src/mgt_sched.f90` (`subroutine mgt_sched`): Moved the loop over plant indices (`do ipl = 1, pcom(j)%npl`) inside the conditional block for output (`if (pco%mgtout == "y")`) to ensure the loop is executed only when output is enabled.