### PR TITLE
0828 -Plant growth and initialization improvements and Sediment budget and output safeguards

### DIFF
--- a/src/pl_leaf_gro.f90
+++ b/src/pl_leaf_gro.f90
@@ -89,15 +89,15 @@
           ff = f - pcom(j)%plg(ipl)%laimxfr
           pcom(j)%plg(ipl)%laimxfr = f
           
-          exponent = plcp(idp)%leaf1 - plcp(idp)%leaf2 * pcom(j)%plcur(ipl)%phuacc_p  ! fg added to check value
+          !exponent = plcp(idp)%leaf1 - plcp(idp)%leaf2 * pcom(j)%plcur(ipl)%phuacc_p  ! fg added to check value
 
-          if (exponent < -16.0) exponent = -16.0                                      ! fg added to check value 
+          !if (exponent < -16.0) exponent = -16.0                                      ! fg added to check value 
           
-          ! f_p = pcom(j)%plcur(ipl)%phuacc_p / (pcom(j)%plcur(ipl)%phuacc_p +            &
-          !     Exp(plcp(idp)%leaf1 - plcp(idp)%leaf2 * pcom(j)%plcur(ipl)%phuacc_p))
+          f_p = pcom(j)%plcur(ipl)%phuacc_p / (pcom(j)%plcur(ipl)%phuacc_p +            &
+               Exp(plcp(idp)%leaf1 - plcp(idp)%leaf2 * pcom(j)%plcur(ipl)%phuacc_p))
 
-          f_p = pcom(j)%plcur(ipl)%phuacc_p / (pcom(j)%plcur(ipl)%phuacc_p +            &  ! fg change
-              Exp(exponent))
+          !f_p = pcom(j)%plcur(ipl)%phuacc_p / (pcom(j)%plcur(ipl)%phuacc_p +            &  ! fg change
+          !    Exp(exponent))
 
           !pcom(j)%plg(ipl)%laimxfr_p = amin1 (f_p, pcom(j)%plg(ipl)%laimxfr_p)
           !ff_p = f_p - pcom(j)%plg(ipl)%laimxfr_p

--- a/src/pl_root_gro.f90
+++ b/src/pl_root_gro.f90
@@ -16,7 +16,6 @@
       real :: rto1 = 0.             !none               |ratio of current years + 1 of growth:years to maturity of perennial
       real :: rto2 = 0.             !none               |ratio of 1 year:years to maturity of perennial
       real :: phumax = 0.
-      real :: rdmax_yr = 0.
              
       idp = pcom(j)%plcur(ipl)%idplt
 
@@ -25,8 +24,10 @@
              pldb(idp)%typ == "warm_annual_tuber" .or. pldb(idp)%typ == "cold_annual_tuber") then
         pcom(j)%plg(ipl)%root_dep = 2.5 * pcom(j)%plcur(ipl)%phuacc * 1000. * pldb(idp)%rdmx
       else
-        pcom(j)%plg(ipl)%root_dep = 2.5 * pcom(j)%plcur(ipl)%phuacc_p * 1000. * pldb(idp)%rdmx
+        rto = float (pcom(j)%plcur(ipl)%curyr_mat) / float (pldb(idp)%mat_yrs)
+        pcom(j)%plg(ipl)%root_dep = 10. * rto * 1000. * pldb(idp)%rdmx
       end if
+      pcom(j)%plg(ipl)%root_dep = Min (pcom(j)%plg(ipl)%root_dep, 1000. * pldb(idp)%rdmx)
       if (pcom(j)%plg(ipl)%root_dep > soil(j)%zmx) pcom(j)%plg(ipl)%root_dep = soil(j)%zmx
       if (pcom(j)%plg(ipl)%root_dep < 25.4) pcom(j)%plg(ipl)%root_dep = 25.4
 

--- a/src/plant_init.f90
+++ b/src/plant_init.f90
@@ -326,7 +326,7 @@
           pcom(j)%plcur(ipl)%curyr_mat = max (1, pcom(j)%plcur(ipl)%curyr_mat)
           ! set total hu to maturity for perennials
           pcom(j)%plcur(ipl)%phumat_p = pcom(j)%plcur(ipl)%phumat * pldb(idp)%mat_yrs
-            
+          pcom(j)%plcur(ipl)%phuacc_p = pcom(j)%plcur(ipl)%phumat_p * pcomdb(icom)%pl(ipl)%fr_yrmat
           cvm_com(j) = plcp(idp)%cvm + cvm_com(j)
           pcom(j)%rsd_covfac = pcom(j)%rsd_covfac + pldb(idp)%rsd_covfac
           rsdco_plcom(j) = rsdco_plcom(j) + pldb(idp)%rsdco_pl

--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -397,23 +397,29 @@
       end do
       
       !! average and write by stream order
-      do iord = 1, 12
-        if (ch_morph_ord(iord)%num > 0) then
-          ch_morph_ord(iord)%w_yr = ch_morph_ord(iord)%w_yr / ch_morph_ord(iord)%num
-          ch_morph_ord(iord)%d_yr = ch_morph_ord(iord)%d_yr / ch_morph_ord(iord)%num
-          ch_morph_ord(iord)%fp_mm = ch_morph_ord(iord)%fp_mm / ch_morph_ord(iord)%num
-        end if
-      end do
+      if (sp_ob%chandeg > 0) then
+        do iord = 1, 12
+          if (ch_morph_ord(iord)%num > 0) then
+            ch_morph_ord(iord)%w_yr = ch_morph_ord(iord)%w_yr / ch_morph_ord(iord)%num
+            ch_morph_ord(iord)%d_yr = ch_morph_ord(iord)%d_yr / ch_morph_ord(iord)%num
+            ch_morph_ord(iord)%fp_mm = ch_morph_ord(iord)%fp_mm / ch_morph_ord(iord)%num
+          end if
+        end do
+      end if
       
       !! write ch_order_sed.txt
-      do iord = 1, 12
-        write (8001,*) iord, ch_morph_ord(iord)%num, ch_morph_ord(iord)%ebank_t,     &
-          ch_morph_ord(iord)%w_yr, ch_morph_ord(iord)%fp_t, ch_morph_ord(iord)%fp_mm
-      end do
+      if (sp_ob%chandeg > 0) then
+        do iord = 1, 12
+          write (8001,*) iord, ch_morph_ord(iord)%num, ch_morph_ord(iord)%ebank_t,     &
+            ch_morph_ord(iord)%w_yr, ch_morph_ord(iord)%fp_t, ch_morph_ord(iord)%fp_mm
+        end do
+      end if
       
       !! upland/channel sediment ratio
-      bsn_sedbud%up_ch_rto = bsn_sedbud%upland_t / bsn_sedbud%ch_ebank_t
-      bsn_sedbud%ch_w_yr = bsn_sedbud%ch_w_yr / sp_ob%chandeg
+      if (bsn_sedbud%ch_ebank_t > 0.) then
+        bsn_sedbud%up_ch_rto = bsn_sedbud%upland_t / bsn_sedbud%ch_ebank_t
+        bsn_sedbud%ch_w_yr = bsn_sedbud%ch_w_yr / sp_ob%chandeg
+      end if
       
       do ires= 1, sp_ob%res
         !! write reservoir trap efficiencies
@@ -425,9 +431,10 @@
       end do
           
       !! basin reservoir deposition and average trap efficiency
-      bsn_sedbud%res_dep_t = bres_in_a%sed - bres_out_a%sed
-      bsn_sedbud%res_trap_eff = bsn_sedbud%res_dep_t / bres_in_a%sed
-      
+      if (bres_in_a%sed > 0.01) then
+        bsn_sedbud%res_dep_t = bres_in_a%sed - bres_out_a%sed
+        bsn_sedbud%res_trap_eff = bsn_sedbud%res_dep_t / bres_in_a%sed
+      end if
       !! write basin sediment budget - ch_sedbud.txt
       write (8002,*) bsn_sedbud 
       


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to plant growth calculations and sediment budget reporting. The most significant changes include corrections to perennial root depth calculation, initialization of plant maturity heat units, and conditional processing for sediment budget outputs to prevent division by zero or unnecessary calculations.

**Plant growth and initialization improvements:**

* Corrected the calculation of perennial plant root depth in `pl_root_gro` to use the ratio of current years to maturity, and added a cap to prevent exceeding maximum root depth.
* Updated perennial plant initialization in `plant_init` to set accumulated heat units to maturity (`phuacc_p`) based on years to maturity.
* Cleaned up and clarified the calculation of the leaf area growth fraction in `pl_leaf_gro`, removing unused variables and ensuring the correct formula is applied.
* Removed an unused variable `rdmax_yr` from `pl_root_gro` for code cleanliness.

**Sediment budget and output safeguards:**

* Added conditional checks in `time_control` to ensure sediment budget calculations and output (such as channel morphology and reservoir deposition) only occur when relevant data is available, preventing divide-by-zero errors and unnecessary processing. [[1]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dR400-R422) [[2]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dR434-R437)