### PR TITLE
0910 updates.

### DIFF
--- a/src/cal_parm_select.f90
+++ b/src/cal_parm_select.f90
@@ -250,6 +250,12 @@
       case ("tile_latk")
         hru(ielem)%sdr%lag = chg_par(hru(ielem)%sdr%latksat,           &
                          chg_typ, chg_val, absmin, absmax)
+                         
+     case ("z")
+          soil(ielem)%zmx = chg_par(soil(ielem)%zmx,                   &
+                         chg_typ, chg_val, absmin, absmax)
+          call soil_awc_init (ielem)
+          call curno (cn2(ielem), ielem)
                       
       !! SOL  
       case ("anion_excl")
@@ -260,11 +266,6 @@
          soil(ielem)%crk = chg_par(soil(ielem)%crk,                      &
                          chg_typ, chg_val, absmin, absmax)
          
-      case ("z")
-          soil(ielem)%phys(ly)%d = chg_par(soil(ielem)%phys(ly)%d,     &
-                         chg_typ, chg_val, absmin, absmax)
-          call soil_awc_init (ielem)
-          call curno (cn2(ielem), ielem)
          
       case ("bd")
           soil(ielem)%phys(ly)%bd = chg_par(soil(ielem)%phys(ly)%bd,    &

--- a/src/main.f90.in
+++ b/src/main.f90.in
@@ -5,7 +5,6 @@
       use maximum_data_module
       use calibration_data_module
       use hru_module
-      use soil_module
 
       implicit none
       
@@ -116,22 +115,9 @@
       
       call proc_open
       
-      !! new checker.out file - always prints
-      open (4000,file = "checker.out",recl=1200)
-      write (4000,*) bsn%name, prog
-      write (4000,*) chk_hdr
-      write (4000,*) chk_unit
-      write (9000,*) "CHK                       checker.out"
-
-      do j = 1, sp_ob%hru
-         write (4000,100) soil(j)%snam, soil(j)%hydgrp, soil(j)%zmx, soil(j)%usle_k, soil(j)%sumfc,  &
-            soil(j)%sumul, hru(j)%lumv%usle_p, hru(j)%lumv%usle_ls, hru(j)%hyd%esco, hru(j)%hyd%epco,      &
-            hru(j)%hyd%cn3_swf, hru(j)%hyd%perco, hru(j)%hyd%latq_co, hru(j)%tiledrain  
-      end do
-
-      100   format(2a16,11f12.4,i12)
-    !! new checker.out file - always prints
-        
+      !! checker output file 
+      if (pco%wb_hru%a == "y") call wb_check
+              
       ! compute unit hydrograph parameters for subdaily runoff
       call unit_hyd_ru_hru
 
@@ -141,12 +127,7 @@
       
       ! save initial time settings for soft calibration runs
       time_init = time
-      !if (bsn_cc%uhyd==1)then
- 
-	  !open(100100,file="paddy_test.csv") !temporary output for paddy Jaehak 2022 
-      !write(100100,'(4a7,20a21)')"Year,","Mon,","Day,","HRU,","Precip,","Irrig,","Seep,","PET,","ET,","WeirH,","Wtrdep,","WeirQ,","SW,","Sedcon,","SedYld,","NO3Con,","NO3Yld,","LAI,","SALT" 
-      !end if
-
+      
       !! simulate watershed processes
       if (time%step < 0) then
         !! export coefficient - average annual

--- a/src/main.f90.in
+++ b/src/main.f90.in
@@ -5,12 +5,14 @@
       use maximum_data_module
       use calibration_data_module
       use hru_module
+      use soil_module
 
       implicit none
       
       integer :: date_time(8)           !              |
       character*10 b(3)                 !              |
       integer :: iob = 0
+      integer :: j = 0                  !none		   |counter
       integer, allocatable, dimension(:) :: cmd_next
     
       prog = " SWAT+ @TODAY@        MODULAR Rev @YEAR@.@SWAT_VERSION@"
@@ -114,6 +116,21 @@
       
       call proc_open
       
+      !! new checker.out file - always prints
+      open (4000,file = "checker.out",recl=1200)
+      write (4000,*) bsn%name, prog
+      write (4000,*) chk_hdr
+      write (4000,*) chk_unit
+      write (9000,*) "CHK                       checker.out"
+
+      do j = 1, sp_ob%hru
+         write (4000,100) soil(j)%snam, soil(j)%hydgrp, soil(j)%zmx, soil(j)%usle_k, soil(j)%sumfc,  &
+            soil(j)%sumul, hru(j)%lumv%usle_p, hru(j)%lumv%usle_ls, hru(j)%hyd%esco, hru(j)%hyd%epco,      &
+            hru(j)%hyd%cn3_swf, hru(j)%hyd%perco, hru(j)%hyd%latq_co, hru(j)%tiledrain  
+      end do
+
+      100   format(2a16,11f12.4,i12)
+    !! new checker.out file - always prints
         
       ! compute unit hydrograph parameters for subdaily runoff
       call unit_hyd_ru_hru

--- a/src/proc_hru.f90
+++ b/src/proc_hru.f90
@@ -47,26 +47,10 @@
       write (4001,*) bsn%name, prog
       write (4001,*) ero_hdr
       write (4001,*) ero_hdr_units
-            
-!!!!! new checker.out file - always prints
-      open (4000,file = "checker.out",recl=1200)
-      write (4000,*) bsn%name, prog
-      write (4000,*) chk_hdr
-      write (4000,*) chk_unit
-      write (9000,*) "CHK                       checker.out"
-
-      do j = 1, sp_ob%hru
-         write (4000,100) soil(j)%snam, soil(j)%hydgrp, soil(j)%zmx, soil(j)%usle_k, soil(j)%sumfc,  &
-            soil(j)%sumul, hru(j)%lumv%usle_p, hru(j)%lumv%usle_ls, hru(j)%hyd%esco, hru(j)%hyd%epco,      &
-            hru(j)%hyd%cn3_swf, hru(j)%hyd%perco, hru(j)%hyd%latq_co, hru(j)%tiledrain  
-      end do
-!!!!! new checker.out file - always prints
         
       end if
 
       call rte_read_nut
-      
-100   format(2a16,11f12.4,i12)
        
       return
       

--- a/src/sd_channel_sediment3.f90
+++ b/src/sd_channel_sediment3.f90
@@ -190,10 +190,10 @@
       
       !! write for Peter
       !if (ich == 2133) then
-      write (7777, *) time%day, time%yrc, ich, sd_ch(ich)%chw, sd_ch(ich)%chd, sd_ch(ich)%chl,   &
-          sd_ch(ich)%chn, sd_ch(ich)%sinu, sd_ch(ich)%pk_rto, pk_rto, peakrate, vel,      &
-          sd_ch(ich)%ch_clay, cohesion, sd_ch(ich)%cov, veg, cohes_fac, sd_ch(ich)%ch_bd, &
-          bd_fac, sd_ch(ich)%vcr_coef, vel_cr, sd_ch(ich)%bank_exp, ebank_m
+      !write (7777, *) time%day, time%yrc, ich, sd_ch(ich)%chw, sd_ch(ich)%chd, sd_ch(ich)%chl,   &
+          !sd_ch(ich)%chn, sd_ch(ich)%sinu, sd_ch(ich)%pk_rto, pk_rto, peakrate, vel,      &
+          !sd_ch(ich)%ch_clay, cohesion, sd_ch(ich)%cov, veg, cohes_fac, sd_ch(ich)%ch_bd, &
+          !bd_fac, sd_ch(ich)%vcr_coef, vel_cr, sd_ch(ich)%bank_exp, ebank_m
       !end if
       
       !! mass of sediment eroded -> t = 1000 * bankcut (mm) * depth (m) * lengthcut (m) * bd (t/m3)

--- a/src/wb_check.f90
+++ b/src/wb_check.f90
@@ -1,0 +1,27 @@
+      subroutine wb_check
+    
+      use basin_module
+      use hydrograph_module
+      use hru_module
+      use soil_module
+      
+      integer :: j = 0                  !none		   |counter
+      
+      !! checker.out file    
+      open (4000,file = "checker.out",recl=1200)
+      write (4000,*) bsn%name, prog
+      write (4000,*) chk_hdr
+      write (4000,*) chk_unit
+      write (9000,*) "CHK                       checker.out"
+
+      do j = 1, sp_ob%hru
+         write (4000,100) soil(j)%snam, soil(j)%hydgrp, soil(j)%zmx, soil(j)%usle_k, soil(j)%sumfc,  &
+            soil(j)%sumul, hru(j)%lumv%usle_p, hru(j)%lumv%usle_ls, hru(j)%hyd%esco, hru(j)%hyd%epco,      &
+            hru(j)%hyd%cn3_swf, hru(j)%hyd%perco, hru(j)%hyd%latq_co, hru(j)%tiledrain  
+      end do
+    !! checker.out file
+      
+100   format(2a16,11f12.4,i12)
+      
+	  return      
+      end


### PR DESCRIPTION
This pull request refactors how the `checker.out` file is generated and modifies the calibration parameter selection logic for soil depth parameters. The main change is moving the code responsible for writing the `checker.out` file from `proc_hru.f90` to a new dedicated subroutine in `wb_check.f90`, and updating the invocation logic in `main.f90`. Additionally, the calibration parameter selection for soil depth now targets a different variable (`zmx` instead of `phys(ly)%d`). Some legacy or debug output statements are also cleaned up.

**Refactoring and output file management:**

* Moved the code for generating the `checker.out` file from the `proc_hru` subroutine in `proc_hru.f90` to a new dedicated subroutine `wb_check` in `wb_check.f90`, improving code organization and modularity. (`[[1]](diffhunk://#diff-86306fb48b28e1cd764002e05ee235175f3b88dc778dbeaece3166aa6e5db9e0L51-L70)`, `[[2]](diffhunk://#diff-e94efef6ae0c41c01847c339cf32f4c6d012d0813ee16eec1ca513adec746b83R1-R27)`)
* Updated `main.f90.in` to call the new `wb_check` subroutine when the appropriate output flag is set, ensuring the checker output file is only written when needed. (`[src/main.f90.inR118-R119](diffhunk://#diff-f915556e91fd531f77d2083899b2703cf25ac963aff9b86c5c5c7d9a89986667R118-R119)`)

**Calibration parameter selection changes:**

* Changed the calibration logic for the `"z"` parameter in `cal_parm_select.f90` to update `soil(ielem)%zmx` instead of `soil(ielem)%phys(ly)%d`, and ensured related initialization routines are called. (`[[1]](diffhunk://#diff-53b7995e35ab21f713ad2d7ed81d8f4c2247e1ec77f5372e6bf95284a428287bR254-R259)`, `[[2]](diffhunk://#diff-53b7995e35ab21f713ad2d7ed81d8f4c2247e1ec77f5372e6bf95284a428287bL263-L267)`)

**Code cleanup:**

* Removed commented-out legacy debug output code from `main.f90.in` and commented out a debug write statement in `sd_channel_sediment3.f90`. (`[[1]](diffhunk://#diff-f915556e91fd531f77d2083899b2703cf25ac963aff9b86c5c5c7d9a89986667L127-L131)`, `[[2]](diffhunk://#diff-e6eea0f3c15a6d8d0d9d1230753faa4fd38b6840a4fd978d62b86d413b93bc13L193-R196)`)

**Minor changes:**

* Added a new integer variable `j` for use as a counter in `main.f90.in` and `wb_check.f90`. (`[[1]](diffhunk://#diff-f915556e91fd531f77d2083899b2703cf25ac963aff9b86c5c5c7d9a89986667R14)`, `[[2]](diffhunk://#diff-e94efef6ae0c41c01847c339cf32f4c6d012d0813ee16eec1ca513adec746b83R1-R27)`)