### PR TITLE
Fix irrigation year reset logic in time_control.f90

### DIFF
--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -255,7 +255,7 @@
               iob = sp_ob1%hru + ihru - 1
               if (ob(iob)%lat < 0) then
                 !! zero yearly irrigation for dtbl conditioning jga6-25
-                hru(ihru)%irr_yr = 0.
+                hru(j)%irr_yr = 0.
                 
                 phubase(ihru) = 0.
                 yr_skip(ihru) = 0
@@ -352,7 +352,7 @@
           iob = sp_ob1%hru + j - 1
           if (ob(iob)%lat >= 0) then
             ! zero yearly irrigation for dtbl conditioning jga6-25
-            hru(ihru)%irr_yr = 0.
+            hru(j)%irr_yr = 0.
             
             phubase(j) = 0.
             yr_skip(j) = 0


### PR DESCRIPTION
This pull request makes a minor correction to the way yearly irrigation is zeroed for HRUs during dtbl conditioning in the `time_control` subroutine. The index used to access the `irr_yr` field of the `hru` array was changed from `ihru` to `j` to ensure the correct HRU is updated.

* Corrected the index for zeroing `hru%irr_yr` from `ihru` to `j` in two places in the `time_control` subroutine, ensuring the intended HRU is targeted. [[1]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL258-R258) [[2]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL355-R355)changed irr_yr counter from ihru to j
This pull request makes small corrections to the way yearly irrigation values are zeroed for HRUs in the `time_control` subroutine. Specifically, it fixes the index used to access the `irr_yr` field, ensuring the correct HRU is updated.
