### PR TITLE
Fix irrigation year reset for specific conditions

### DIFF
--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -255,7 +255,7 @@
               iob = sp_ob1%hru + ihru - 1
               if (ob(iob)%lat < 0) then
                 !! zero yearly irrigation for dtbl conditioning jga6-25
-                hru(ihru)%irr_yr = 0.
+                hru(j)%irr_yr = 0.
                 
                 phubase(ihru) = 0.
                 yr_skip(ihru) = 0
@@ -352,7 +352,7 @@
           iob = sp_ob1%hru + j - 1
           if (ob(iob)%lat >= 0) then
             ! zero yearly irrigation for dtbl conditioning jga6-25
-            hru(ihru)%irr_yr = 0.
+            hru(j)%irr_yr = 0.
             
             phubase(j) = 0.
             yr_skip(j) = 0


### PR DESCRIPTION
This pull request makes small corrections to how yearly irrigation values are zeroed for HRUs in the `time_control` subroutine. The changes ensure that the correct HRU index is used when resetting irrigation values, which improves code accuracy and prevents potential indexing errors.

* Corrected the assignment of the yearly irrigation value to use `hru(j)%irr_yr` instead of `hru(ihru)%irr_yr` in two places, ensuring the correct HRU is updated. [[1]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL258-R258) [[2]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL355-R355)