### PR TITLE
Fix irrigation year reset for specific indices

### DIFF
--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -255,7 +255,7 @@
               iob = sp_ob1%hru + ihru - 1
               if (ob(iob)%lat < 0) then
                 !! zero yearly irrigation for dtbl conditioning jga6-25
-                hru(ihru)%irr_yr = 0.
+                hru(j)%irr_yr = 0.
                 
                 phubase(ihru) = 0.
                 yr_skip(ihru) = 0
@@ -352,7 +352,7 @@
           iob = sp_ob1%hru + j - 1
           if (ob(iob)%lat >= 0) then
             ! zero yearly irrigation for dtbl conditioning jga6-25
-            hru(ihru)%irr_yr = 0.
+            hru(j)%irr_yr = 0.
             
             phubase(j) = 0.
             yr_skip(j) = 0


### PR DESCRIPTION
Fix to the yearly irrigation reset logic in the `time_control` subroutine. The change ensures that the correct index is used when zeroing out yearly irrigation values, which helps maintain consistency in data handling for both northern and southern latitudes.

* Corrected the index used for zeroing yearly irrigation in both southern (`ob(iob)%lat < 0`) and northern (`ob(iob)%lat >= 0`) latitude condition blocks, changing from `hru(ihru)%irr_yr` to `hru(j)%irr_yr`. [[1]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL258-R258) [[2]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL355-R355).  The change ensures that the correct HRU index is used when setting `irr_yr` to zero, which improves consistency and prevents potential indexing errors.



* Corrected the index used to zero out `hru%irr_yr` from `ihru` to `j` in two conditional blocks within `src/time_control.f90`, ensuring the intended HRU is updated. [[1]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL258-R258) [[2]](diffhunk://#diff-4d3899e306db1ddf07f18a0a072cc9ac0830558cd8c3eaa79d82320b6a20ee0dL355-R355)