### PR TITLE
Fix HRU incoming hydrograph indexing

### DIFF
--- a/src/hyd_connect.f90
+++ b/src/hyd_connect.f90
@@ -388,6 +388,8 @@
               do ielem = 1, ru_def(iru)%num_tot
                 ielem_db = ru_def(iru)%num(ielem)
                 kk = ru_elem(ielem_db)%obj
+                rcv_sum(kk) = rcv_sum(kk) + 1                   ! setting sequential receiving hyd number
+                jj = rcv_sum(kk)  
                 ob(kk)%obj_in(jj) = i                       ! source object number (for receiving unit)
                 ob(kk)%obtyp_in(jj) = ob(i)%typ
                 ob(kk)%obtypno_in(jj) = ob(i)%props


### PR DESCRIPTION
This PR fixes an indexing issue during model initialization that affects how hydrologic objects HRUs are assigned their incoming hydrographs.

During model initialization, each hydrologic object (HRU, RU, channel, etc.) is assigned its incoming hydrographs and corresponding metadata. A counter, `rcv_sum(kk)`, tracks how many incoming hydrographs each receiving object (`kk`) has, ensuring that each hydrograph is stored in a unique slot (`jj`) in its connectivity arrays `ob(kk`) (`%obj_in`, `%frac_in`, `%htyp_in`, etc.).
When the receiving object is a RU, the code uses a dedicated inner loop (line 386 in hyd_connect.f90) to distribute the RU’s incoming hydrographs to each of its contained elements (typically HRUs), based on area fraction.

**Problem**
This inner loop correctly routed RU outflows to each HRU within the RU but did not increment `rcv_sum(kk)` or update the index `jj` for the receiving HRU `kk`. As a result, the `rcv_sum(kk)` counter for the HRU could be incorrect, and the index `jj` used for assigning incoming hydrographs is inherited from the parent RU instead of being specific to the HRU.
In most standard SWAT+ configurations using floodplain/upland delineation, each HRU only receives inflow from its upland RU. In such cases, the omission causes no practical issue, since the RU and HRU shared the same number of incoming hydrographs.

However, in configurations where an HRU receives additional inflows (e.g., from an aquifer, channel, or another HRU), this causes index collisions as multiple inflows can be assigned to the same `jj` slot.

**Example**
HRU1 is contained in RU1 (floodplain). RU1 receives hydrographs from RU2 (upland) and directly from Aquifer AQU1.
Without incrementing the `rcv_sum()` counter and updating the index `jj` in the RU to HRU loop, both incoming hydrographs for HRU1 would be assigned to the same slot (jj = 1), leading to overwriting and errors.

**Fix**
The following lines were added inside the RU to HRU distribution loop:
```
rcv_sum(kk) = rcv_sum(kk) + 1
jj = rcv_sum(kk)
```
This ensures that each HRU’s incoming hydrographs are uniquely indexed and correctly stored.
