### PR TITLE
bug fixed: change the allowed lowest perco to 1.e-6 to avoid negative…

### DIFF
--- a/src/cal_parm_select.f90
+++ b/src/cal_parm_select.f90
@@ -151,7 +151,7 @@
         if (hru(ielem)%tiledrain == 0) then
         hru(ielem)%hyd%perco = chg_par (hru(ielem)%hyd%perco,           &
                          chg_typ, chg_val, absmin, absmax)
-        if (hru(ielem)%hyd%perco > 1.e-9) then
+        if (hru(ielem)%hyd%perco > 1.e-6) then
           perc_ln_func = 1.0052 * log(-log(hru(ielem)%hyd%perco - 1.e-6)) + 5.6862
           hru(ielem)%hyd%perco_lim = exp(-perc_ln_func)
           hru(ielem)%hyd%perco_lim = amin1 (1., hru(ielem)%hyd%perco_lim)


### PR DESCRIPTION
bug fixed: change the allowed lowest perco to 1.e-6 to avoid negative value for log()

If `hru(ielem)%hyd%perco > 1.e-9` and `hru(ielem)%hyd%perco < 1.e-6`, the `log()` will receive a negative value, resulting in a math error. I recommend changing it to `hru(ielem)%hyd%perco > 1.e-6`.
```fortran
if (hru(ielem)%hyd%perco > 1.e-9) then
          perc_ln_func = 1.0052 * log(-log(hru(ielem)%hyd%perco - 1.e-6)) + 5.6862
```
