### PR TITLE
Integrate CENTURY residue/N updates and root-fraction tracking changes

### DIFF
--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -682,15 +682,10 @@
               
         !     update
               if (rnmn > 0.) then
-                soil1(j)%mn(k)%nh4 = soil1(j)%mn(k)%nh4 + rnmn     
-                min_n = soil1(j)%mn(k)%no3 - rnmn
-                if (min_n < 0.) then
-                  rnmn = -soil1(j)%mn(k)%no3
-                  soil1(j)%mn(k)%no3 = 1.e-10
-                else
-                  soil1(j)%mn(k)%no3 = min_n
-                end if   
-                ! print*, "2. in cbn_zhang2", k, soil1(j)%mn(k)%no3, rnmn
+                min_n = Max(0., soil1(j)%mn(k)%no3 - rnmn)
+                soil1(j)%mn(k)%nh4 = soil1(j)%mn(k)%nh4 + min_n
+                soil1(j)%mn(k)%no3 = soil1(j)%mn(k)%no3 - min_n
+                ! print*, "2. in cbn_zhang2", k, soil1(j)%mn(k)%no3, min_n
               end if
               
 	          ! calculate p flows
@@ -704,7 +699,7 @@
               soil1(j)%mp(k)%lab = soil1(j)%mp(k)%lab + hmp	          
 	
 	          !! compute residue decomp and mineralization of 
-              !! fresh organic n and p (upper two layers only)  
+              !! fresh organic n and p  
                 decr = (lscta + lmcta) / (soil1(j)%str(k)%c + soil1(j)%meta(k)%c + 1.e-6)
                 decr = min(1., decr)
                 rmp = decr * soil1(j)%tot(k)%p

--- a/src/hru_control.f90
+++ b/src/hru_control.f90
@@ -50,8 +50,7 @@
                   rsd_decomp, salt_chem_hru, salt_lch, salt_rain, salt_roadsalt, smp_bmpfixed, smp_filter, &
                   smp_grass_wway, sq_canopyint, sq_snom, sq_surfst, stmp_solt, stor_surfstor, surface, &
                   swr_latsed, swr_percmain, swr_substor, swr_subwq, varinit, wet_irrp, wetland_control, &
-                  sq_crackvol, mgt_operatn, mgt_newtillmix, sep_biozone, pest_washp, pest_pesty, smp_buffer, &
-                  pl_rootfr
+                  sq_crackvol, mgt_operatn, mgt_newtillmix, sep_biozone, pest_washp, pest_pesty, smp_buffer
 
       integer :: j = 0              !none          |same as ihru (hru number)
       integer :: j1 = 0             !none          |counter (rtb)
@@ -367,14 +366,11 @@
           end if
         end if
        
-        !! compute surface residue decomposition for each plant in community 
-        !! if cswat not equal to 2
-        if (bsn_cc%cswat /= 2) then
-          call rsd_decomp
-        end if
-        
         !! compute residue decomposition and nitrogen and phosphorus mineralization
         if (bsn_cc%cswat == 0) then
+          !! compute surface residue decomposition for each plant in community
+          call rsd_decomp
+          !! compute soil residue (roots and tilled in) decomposition and nitrogen and phosphorus mineralization
           call nut_nminrl
           !call nut_nitvol
         end if
@@ -382,7 +378,11 @@
         !! compute residue decomposition and nitrogen and phosphorus mineralization
         if (bsn_cc%cswat == 2) then
           if (bmix_eff > 1.e-6) call mgt_newtillmix (ihru, bmix_eff, 0)
+          !! compute surface residue decomposition for each plant in community
+          call cbn_surfrsd_decomp
+          !! compute soil residue (roots and tilled in) decomposition
           call cbn_rsd_decomp      ! added by JC and FG, modified from nut_minrln.f90
+          !! compute mineralization and carbon pool transformations
           call cbn_zhang2
         end if
 
@@ -445,9 +445,6 @@
         !! compute plant biomass, leaf, root and seed growth
         call pl_grow
 
-        !! Distribute roots
-        call pl_rootfr
-
         !! reset harvested biomass and number of harvests for yearly yield output
         if (time%end_yr == 1) then
           do ipl = 1, pcom(j)%npl
@@ -480,7 +477,7 @@
           strstmp_av = strstmp_av / npl_gro
         end if
 
-        !! compute soil water content to 300 mm depth
+        !! compute aoil water content to 300 mm depth
         soil(j)%sw_300 = 0.
         do ly = 1, soil(j)%nly
           if (ly == 1) then

--- a/src/mgt_harvtuber.f90
+++ b/src/mgt_harvtuber.f90
@@ -47,12 +47,12 @@
       pl_mass(j)%root(ipl) = pl_mass(j)%root(ipl) - pl_yield
       
       !! update root fractions in each layer
-      call pl_rootfr
+      call pl_rootfr(j)
       
       !! allocate remaining dead roots, N, P to soil layers
       do ly = 1, soil(j)%nly
-        pl_mass(j)%rsd(ipl) = soil(j)%ly(ly)%rtfr * pl_mass(j)%root(ipl)   &
-                                                   + pl_mass(j)%rsd(ipl)
+        soil1(j)%pl(ipl)%rsd(ly) = soil1(j)%pl(ipl)%rsd(ly) + pcom(j)%plg(ipl)%rtfr(ly) *  &
+                                                                      pl_mass(j)%root(ipl)
       end do
       
       !! apply pest stress to harvest index - mass lost due to pests - don't add to residue

--- a/src/mgt_killop.f90
+++ b/src/mgt_killop.f90
@@ -23,10 +23,10 @@
       integer :: ly = 0                !none           |soil layer
 
       j = jj
-      ! ipl = iplant
+      ipl = iplant
 
       !! update root fractions in each layer
-      call pl_rootfr
+      call pl_rootfr(j)
       
       !! add above ground biomass to surface residue pools
       pl_mass(j)%rsd(ipl) = pl_mass(j)%rsd(ipl) + pl_mass(j)%ab_gr(ipl)
@@ -39,8 +39,8 @@
       
       !! add dead roots to soil residue pools
       do ly = 1, soil(j)%nly
-        soil1(j)%pl(ipl)%rsd(ly) = soil1(j)%pl(ipl)%rsd(ly) + soil(j)%ly(ly)%rtfr * pl_mass(j)%root(ipl)
-        soil(j)%ly(ly)%rtfr = 0.0
+        soil1(j)%pl(ipl)%rsd(ly) = soil1(j)%pl(ipl)%rsd(ly) + pcom(j)%plg(ipl)%rtfr(ly)  &
+                                                                  * pl_mass(j)%root(ipl)
       end do
       
       !! sum total community masses
@@ -72,7 +72,7 @@
       end do
 
       !! reset plant variables
-      pcom(j)%plg(ipl) = plgz
+      call plg_zero (pcom(j)%plg(ipl))
       pcom(j)%plm(ipl) = plmz
       pcom(j)%plstr(ipl) = plstrz
       !! can't reset entire plcur - harv_num can't be zero'd

--- a/src/mgt_newtillmix.f90
+++ b/src/mgt_newtillmix.f90
@@ -232,8 +232,12 @@
             
             !! reconstitute each plant residue component separately
             do ipl = 1, pcom(jj)%npl
-              soil1(jj)%pl(ipl)%rsd(l) = frac_non_mixed * soil1(jj)%pl(ipl)%rsd(l) +     &
+              soil1(jj)%pl(ipl)%rsd(l) = frac_non_mixed * soil1(jj)%pl(ipl)%rsd(l) +        &
                                                          frac_dep(l) * mix_org%rsd(ipl)
+              !! mix surface residue into soil layers
+              mix_org%surf_rsd = emix * frac_dep(l) * pl_mass(jj)%rsd(ipl)
+              soil1(jj)%pl(ipl)%rsd(l) = soil1(jj)%pl(ipl)%rsd(l) + mix_org%surf_rsd
+              pl_mass(jj)%rsd(ipl) = pl_mass(jj)%rsd(ipl) - mix_org%surf_rsd
             end do
             
             soil1(jj)%hact(l) = frac_non_mixed * soil1(jj)%hact(l) + frac_dep(l) * mix_org%hact

--- a/src/nut_orgnc2.f90
+++ b/src/nut_orgnc2.f90
@@ -30,41 +30,37 @@
       implicit none
 
       integer :: j = 0       !none          |HRU number
-      real :: xx = 0.        !kg N/ha       |amount of organic N in first soil layer
+      integer :: ly = 0       !none          |soil layer number 
+      real :: flo_loss_co = 0.        !kg N/ha       |amount of organic N in first soil layer
       real :: wt1 = 0.       !none          |conversion factor (mg/kg => kg/ha)
       real :: er = 0.        !none          |enrichment ratio
       real :: conc = 0.      !              |concentration of organic N in soil
       real :: sol_mass = 0.  !              |  
-      real :: QBC = 0.              !              |c loss with runoff or lateral flow
-      real :: VBC = 0.              !              |c los with vertical flow
-      real :: YBC = 0.              !              |BMC LOSS WITH SEDIMENT
-      real :: YOC = 0.              !              |Organic C loss with sediment
-      real :: YW = 0.               !              |YW = WIND EROSION (T/HA)
-      real :: TOT = 0.              !              |Total organic carbon in layer 1
-      real :: YEW = 0.              !frac          |fraction of soil erosion of total soil mass
-      real :: X1 = 0.               !              |
-      real :: PRMT_21 = 0.          !              |KOC FOR CARBON LOSS IN WATER AND SEDIMENT(500._1500.) KD = KOC * C
-      real :: PRMT_44 = 0.          !              |RATIO OF SOLUBLE C CONCENTRATION IN RUNOFF TO PERCOLATE(0.1_1.)
-      real :: DK = 0.               !              |
-      real :: V = 0.                !              |
-      real :: X3 = 0.               !              | 
-      real :: CO = 0.               !              | 
-      real :: CS = 0.               !              | 
+      real :: c_surlat = 0.         !              |c loss with runoff or lateral flow
+      real :: c_vert = 0.           !              |c loss with vertical flow
+      real :: c_horiz = 0.           !              |c loss with vertical flow
+      real :: c_microb = 0.         !              |BMC LOSS WITH SEDIMENT
+      real :: c_sed = 0.            !              |Organic C loss with sediment
+      real :: ero_fr = 0.           !frac          |fraction of soil erosion of total soil mass
+      real :: koc = 0.          !              |KOC FOR CARBON LOSS IN WATER AND SEDIMENT(500._1500.) KD = KOC * C
+      real :: c_microb_fac = 0.               !              |
+      real :: flo_tot = 0.          !mm            |total flow from the soil layer
+      real :: c_microb_loss = 0.               !              | 
+      real :: horiz_conc = 0.               !              | 
+      real :: vert_conc = 0.               !              | 
       real :: perc_clyr = 0.        !              | 
       real :: latc_clyr = 0.        !              | 
-      integer :: k = 0              !none          |counter 
-      real :: xx1 = 0.              !              |
-      real :: sol_thick = 0.        !              |
-      real :: y1 = 0.               !              |
+      real :: n_left_rto = 0.              !              |
+      real :: c_microb_perc = 0.               !              |
+      real :: c_microb_sed = 0.               !              |
       real :: c_ly1 = 0.
-      !real :: ipl                   !              |counter for plant in the community
       
       j = ihru
       
       latc_clyr = 0.        
       perc_clyr = 0.
-      wt1 = 0.  !! conversion factor
-      er = 0.   !! enrichment ratio
+      wt1 = 0.
+      er = 0.
       
       !! total carbon in surface residue and soil humus
       c_ly1 = soil1(j)%hp(1)%n + soil1(j)%hs(1)%n + pl_mass(j)%rsd_tot%n
@@ -77,115 +73,96 @@
         er = enratio
       end if
 
-      conc = c_ly1 * er / wt1
-
       !! organic n leaving hru
+      conc = c_ly1 * er / wt1
       sedorgn(j) = .001 * conc * sedyld(j) / hru(j)%area_ha
 
       !! update soil carbon organic nitrogen pools
       if (c_ly1 > 1.e-6) then
-        xx1 = (1. - sedorgn(j) / c_ly1)
-        soil1(j)%tot(1)%n = soil1(j)%tot(1)%n * xx1
-        soil1(j)%hs(1)%n = soil1(j)%hs(1)%n * xx1
-        soil1(j)%hp(1)%n = soil1(j)%hp(1)%n * xx1
+        n_left_rto = (1. - sedorgn(j) / c_ly1)
+        soil1(j)%tot(1)%n = soil1(j)%tot(1)%n * n_left_rto
+        soil1(j)%hs(1)%n = soil1(j)%hs(1)%n * n_left_rto
+        soil1(j)%hp(1)%n = soil1(j)%hp(1)%n * n_left_rto
         do ipl = 1, pcom(j)%npl
-          pl_mass(j)%rsd(1)%n =   pl_mass(j)%rsd(1)%n * xx1
+          pl_mass(j)%rsd(1)%n =   pl_mass(j)%rsd(1)%n * n_left_rto
         end do
-        soil1(j)%meta(1)%n = soil1(j)%meta(1)%n * xx1
-        soil1(j)%str(1)%n = soil1(j)%str(1)%n * xx1
-        soil1(j)%lig(1)%n = soil1(j)%lig(1)%n * xx1
+        soil1(j)%meta(1)%n = soil1(j)%meta(1)%n * n_left_rto
+        soil1(j)%str(1)%n = soil1(j)%str(1)%n * n_left_rto
+        soil1(j)%lig(1)%n = soil1(j)%lig(1)%n * n_left_rto
       end if
       
       !! Calculate runoff and leached C&N from microbial biomass
       latc_clyr = 0.
       sol_mass = (soil(j)%phys(1)%d / 1000.) * 10000. * soil(j)%phys(1)%bd * 1000. * (1- soil(j)%phys(1)%rock / 100.)
       
-      QBC=0.    !c loss with runoff or lateral flow
-      VBC=0.    !c los with vertical flow
-      YBC=0.    !BMC LOSS WITH SEDIMENT
-      YOC=0.    !Organic C loss with sediment
-      YW=0.     !YW = WIND EROSION (T/HA)
-      TOT = soil1(j)%hp(1)%c + soil1(j)%hs(1)%c + soil1(j)%meta(1)%c + soil1(j)%str(1)%c !Total organic carbon in layer 1
-      !YEW = MIN(er*(sedyld(j)/hru(j)%area_ha+YW/hru(j)%area_ha)/(sol_mass/1000.),.9)
-      ! Not sure whether should consider enrichment ratio or not!
-      YEW = MIN((sedyld(j)/hru(j)%area_ha+YW/hru(j)%area_ha)/(sol_mass/1000.),.9) !fraction of soil erosion of total soil mass
-      X1=1.- YEW
-      !YEW=MIN(ER*(YSD(NDRV)+YW)/WT(LD1),.9)
-      !ER enrichment ratio
-      !YSD water erosion
-      !YW wind erosion
-      YOC=YEW*TOT
-      soil1(j)%tot(1)%c = soil1(j)%tot(1)%c * X1
-      soil1(j)%hs(1)%c = soil1(j)%hs(1)%c * X1
-      soil1(j)%hp(1)%c = soil1(j)%hp(1)%c * X1
+      c_surlat = 0.
+      c_vert = 0.
+      c_microb = 0.
+      c_sed = 0.
+      soil1(j)%tot(1)%c = soil1(j)%hp(1)%c + soil1(j)%hs(1)%c + soil1(j)%meta(1)%c + soil1(j)%str(1)%c !Total organic carbon in layer 1
+      ero_fr = MIN((sedyld(j)/hru(j)%area_ha) / (sol_mass / 1000.),.9) !fraction of soil erosion of total soil mass
+      c_sed = ero_fr * soil1(j)%tot(1)%c
+      soil1(j)%tot(1)%c = soil1(j)%tot(1)%c * (1.- ero_fr)
+      soil1(j)%hs(1)%c = soil1(j)%hs(1)%c * (1.- ero_fr)
+      soil1(j)%hp(1)%c = soil1(j)%hp(1)%c * (1.- ero_fr)
       do ipl = 1, pcom(j)%npl
-        pl_mass(j)%rsd(ipl)%c =   pl_mass(j)%rsd(ipl)%c * X1
+        pl_mass(j)%rsd(ipl)%c = pl_mass(j)%rsd(ipl)%c * (1.- ero_fr)
       end do
           
         
       if (soil1(j)%microb(1)%c > .01) then
-          PRMT_21 = cb_wtr_coef%prmt_21 !KOC FOR CARBON LOSS IN WATER AND SEDIMENT(500._1500.) KD = KOC * C
-          soil1(j)%tot(1)%c = soil1(j)%str(1)%c + soil1(j)%meta(1)%c + soil1(j)%hp(1)%c + soil1(j)%hs(1)%c + soil1(j)%microb(1)%c 
-          DK = .0001 * PRMT_21 * soil1(j)%tot(1)%c
-          !X1=PO(LD1)-S15(LD1)
-          X1 = soil(j)%phys(1)%por*soil(j)%phys(1)%d-soil(j)%phys(1)%wpmm !mm
-          IF (X1 <= 0.) THEN
-            X1 = 0.01
-          END IF
-          XX=X1+DK
-          V = surfq(j) + soil(j)%ly(1)%prk + soil(j)%ly(1)%flat
-          !QD surface runoff
-          X3=0.
-          IF(V>1.E-10)THEN
-              X3 = soil1(j)%microb(1)%c * (1.-EXP(-V/XX)) !loss of biomass C
-              PRMT_44 = cb_wtr_coef%prmt_44  !RATIO OF SOLUBLE C CONCENTRATION IN RUNOFF TO PERCOLATE(0.1_1.)
-              CO = X3/(soil(j)%ly(1)%prk + PRMT_44 * (surfq(j) + soil(j)%ly(1)%flat)) !CS is the horizontal concentration
-              CS = PRMT_44*CO                                     !CO is the vertical concentration
-              VBC = CO*(soil(j)%ly(1)%prk) 
-              soil1(j)%microb(1)%c = soil1(j)%microb(1)%c - X3
-              QBC = CS*(surfq(j)+soil(j)%ly(1)%flat)
-        !     COMPUTE WBMC LOSS WITH SEDIMENT
-              IF(YEW>0.)THEN
-                  CS = DK * soil1(j)%microb(1)%c / XX
-                  YBC = YEW * CS
-              END IF
-          END IF
-      END IF
-
-      soil1(j)%microb(1)%c = soil1(j)%microb(1)%c - YBC 
-      soil1(j)%tot(1)%c = soil1(j)%str(1)%c + soil1(j)%meta(1)%c + soil1(j)%hp(1)%c + soil1(j)%hs(1)%c + soil1(j)%microb(1)%c 
-      hsc_d(j)%surq_c = QBC * (surfq(j) / (surfq(j) + soil(j)%ly(1)%flat + 1.e-6))
-       
-      soil(j)%ly(1)%latc = QBC*(soil(j)%ly(1)%flat/(surfq(j)+soil(j)%ly(1)%flat+1.e-6))
-      soil(j)%ly(1)%percc = VBC 
-      hsc_d(j)%sed_c = YOC + YBC
-      
-      do k = 2, soil(j)%nly
-          ! if (soil(j)%ly(k)%prk > 0 .and. k == soil(j)%nly) then   ! commented out by FG because it doesn't do anything.
-          ! end if
-          sol_thick = 0.
-          sol_thick = soil(j)%phys(k)%d-soil(j)%phys(k-1)%d
-          ! soil1(j)%tot(1)%c = soil1(j)%hp(k)%c + soil1(j)%hs(k)%c 
-          ! soil1(j)%tot(k)%c = soil1(j)%hp(k)%c + soil1(j)%hs(k)%c  ! commented out by FG because is not needed here.
-          Y1 = soil1(j)%microb(k)%c + VBC
-          VBC=0.
-          IF(Y1>=.01)THEN
-              V=soil(j)%ly(k)%prk + soil(j)%ly(k)%flat
-              IF(V>0.)VBC=Y1*(1.-EXP(-V/(soil(j)%phys(k)%por*sol_thick-soil(j)%phys(k)%wpmm+.0001*PRMT_21*soil1(j)%water(1)%c)))              
-          END IF
-          soil(j)%ly(k)%latc = VBC*(soil(j)%ly(k)%flat/(soil(j)%ly(k)%prk + soil(j)%ly(k)%flat+1.e-6))
-          soil(j)%ly(k)%percc = VBC-soil(j)%ly(k)%latc
-          soil1(j)%microb(k)%c = Y1 - VBC
-
-          !! calculate nitrate in percolate and lateral flow
-          if (k == soil(j)%nly) then
-            hsc_d(j)%perc_c = soil(j)%ly(k)%percc
+        koc = cb_wtr_coef%prmt_21 !KOC FOR CARBON LOSS IN WATER AND SEDIMENT(500._1500.) KD = KOC * C
+        soil1(j)%tot(1)%c = soil1(j)%str(1)%c + soil1(j)%meta(1)%c + soil1(j)%hp(1)%c + soil1(j)%hs(1)%c + soil1(j)%microb(1)%c 
+        c_microb_fac = .0001 * koc * soil1(j)%tot(1)%c
+        flo_loss_co = soil(j)%phys(1)%ul + c_microb_fac
+        flo_tot = surfq(j) + soil(j)%ly(1)%prk + soil(j)%ly(1)%flat
+        c_microb_loss = 0.
+        if (flo_tot > 1.E-10) then
+          c_microb_loss = soil1(j)%microb(1)%c * (1. - EXP(-flo_tot / flo_loss_co)) !loss of biomass C
+          !! cb_wtr_coef%prmt_44 is the ratio of soluble C conc - runoff/perc (0.1-1.)
+          vert_conc = c_microb_loss / (soil(j)%ly(1)%prk + cb_wtr_coef%prmt_44 * (surfq(j) + soil(j)%ly(1)%flat))
+          horiz_conc = cb_wtr_coef%prmt_44 * vert_conc
+          c_horiz = vert_conc * soil(j)%ly(1)%prk 
+          soil1(j)%microb(1)%c = soil1(j)%microb(1)%c - c_microb_loss
+          c_surlat = vert_conc * (surfq(j) + soil(j)%ly(1)%flat)
+          !! microbial carbon loss with sediment
+          if (ero_fr > 0.) then
+            c_horiz = c_microb_fac * soil1(j)%microb(1)%c / flo_loss_co
+            c_microb_sed = ero_fr * c_horiz
           end if
-          latc_clyr = latc_clyr + soil(j)%ly(k)%latc
+        end if
+      end if
 
-          soil1(j)%tot(k)%c = soil1(j)%str(k)%c + soil1(j)%meta(k)%c + soil1(j)%hp(k)%c + soil1(j)%hs(k)%c + soil1(j)%microb(k)%c 
-          soil1(j)%seq(k)%c = soil1(j)%hp(k)%c + soil1(j)%hs(k)%c + soil1(j)%microb(k)%c 
+      soil1(j)%microb(1)%c = soil1(j)%microb(1)%c - c_microb_sed 
+      soil1(j)%tot(1)%c = soil1(j)%str(1)%c + soil1(j)%meta(1)%c + soil1(j)%hp(1)%c + soil1(j)%hs(1)%c + soil1(j)%microb(1)%c 
+      hsc_d(j)%surq_c = c_surlat * (surfq(j) / (surfq(j) + soil(j)%ly(1)%flat + 1.e-6))
+       
+      soil(j)%ly(1)%latc = c_surlat * (soil(j)%ly(1)%flat / (surfq(j) + soil(j)%ly(1)%flat + 1.e-6))
+      soil(j)%ly(1)%percc = c_vert 
+      hsc_d(j)%sed_c = c_sed + c_microb_sed
+      
+      do ly = 2, soil(j)%nly
+        c_microb_perc = soil1(j)%microb(ly)%c + c_vert
+        c_vert = 0.
+        if (c_microb_perc >=.01) then
+          flo_tot = soil(j)%ly(ly)%prk + soil(j)%ly(ly)%flat
+          if (flo_tot > 0.) then
+            c_vert = c_microb_perc * (1. - EXP(-flo_tot / (soil(j)%phys(ly)%por * soil(j)%phys(ly)%thick  &
+                                                           - soil(j)%phys(ly)%wpmm + .0001 * koc * soil1(j)%water(1)%c)))
+          end if
+        end if
+        soil(j)%ly(ly)%latc = c_vert * (soil(j)%ly(ly)%flat/(soil(j)%ly(ly)%prk + soil(j)%ly(ly)%flat+1.e-6))
+        soil(j)%ly(ly)%percc = c_vert - soil(j)%ly(ly)%latc
+        soil1(j)%microb(ly)%c = c_microb_perc - c_vert
 
+        !! calculate carbon in percolate and lateral flow
+        if (ly == soil(j)%nly) then
+          hsc_d(j)%perc_c = soil(j)%ly(ly)%percc
+        end if
+        latc_clyr = latc_clyr + soil(j)%ly(ly)%latc
+
+        soil1(j)%tot(ly)%c = soil1(j)%str(ly)%c + soil1(j)%meta(ly)%c + soil1(j)%hp(ly)%c + soil1(j)%hs(ly)%c + soil1(j)%microb(ly)%c 
+        soil1(j)%seq(ly)%c = soil1(j)%hp(ly)%c + soil1(j)%hs(ly)%c + soil1(j)%microb(ly)%c
       end do
      
       hsc_d(j)%latq_c = latc_clyr

--- a/src/organic_mineral_mass_module.f90
+++ b/src/organic_mineral_mass_module.f90
@@ -16,9 +16,10 @@
       end type organic_mass
       type (organic_mass) :: orgz
 
-      type organic_mixing_mass
+      type organic_mixing_mass           !       |used for each layer in mgt_newtillmix
         type (organic_mass) :: tot       !       |total organic pool
-        type (organic_mass), dimension(12) :: rsd   !   |fresh residue
+        type (organic_mass) :: surf_rsd  !   |fresh surface residue mixed into layers
+        type (organic_mass), dimension(12) :: rsd   !   |fresh soil residue (max 12 plants)
         !! humus pools for old mineralization model (static carbon)
         type (organic_mass) :: hact      !       |active humus for old mineralization model
         type (organic_mass) :: hsta      !       |stable humus for old mineralization model

--- a/src/pl_mortality.f90
+++ b/src/pl_mortality.f90
@@ -40,8 +40,8 @@
         
         !! add dead roots to soil residue pools
         do ly = 1, soil(j)%nly
-          soil1(j)%pl(ipl)%rsd(ly) = soil1(j)%pl(ipl)%rsd(ly) + rto * soil(j)%ly(ly)%rtfr &
-                                                                    * pl_mass(j)%root(ipl)
+          soil1(j)%pl(ipl)%rsd(ly) = soil1(j)%pl(ipl)%rsd(ly) + rto * pcom(j)%plg(ipl)%rtfr(ly) &
+                                                                          * pl_mass(j)%root(ipl)
         end do
 
         ! Reduce remaining living biomass  

--- a/src/pl_root_gro.f90
+++ b/src/pl_root_gro.f90
@@ -47,8 +47,5 @@
         pcom(j)%plg(ipl)%root_frac = pldb(idp)%rsr1 - (pldb(idp)%rsr1 - pldb(idp)%rsr2) * phumax
       end if
       
-      !! root mass
-      !pl_mass(j)%root(ipl)%m = pcom(j)%plg(ipl)%root_frac * pl_mass(j)%tot(ipl)%m
-
       return
       end subroutine pl_root_gro

--- a/src/pl_rootfr.f90
+++ b/src/pl_rootfr.f90
@@ -1,24 +1,22 @@
-      subroutine pl_rootfr  
+    subroutine pl_rootfr(j)
     !! This subroutine distributes dead root mass through the soil profile
     !! code developed by Armen R. Kemanian in 2008 
     !! March, 2009 further adjustments expected
     
-    ! use hru_module, only : ihru
-    use hru_module, only : ihru, ipl
+    use hru_module, only : ipl
     use soil_module
     use plant_module
     
     implicit none    
 
-    real :: sol_thick(soil(ihru)%nly) !            |
     real :: cum_rd = 0.               !            |
     real :: cum_d = 0.                !            | 
     real :: cum_rf = 0.               !            |
     real :: x1 = 0.                   !            |
     real :: x2 = 0.                   !            |
+    integer, intent (in) :: j         !none               |HRU number
     integer :: k = 0                  !            |
-    integer :: l = 0                  !none        |number of soil layer that manure applied
-    integer :: jj = 0                 !none        |counter
+    integer :: ly = 0                 !none        |number of soil layer that manure applied
     real :: a = 0.                    !            |
     real :: b = 0.                    !            |
     real :: c = 0.                    !            | 
@@ -27,78 +25,59 @@
     real :: xx1 = 0.                  !            |
     real :: xx2 = 0.                  !            |
     real :: xx = 0.                   !            |
-    integer :: ipl_grow = 0
-
     
-    jj = ihru
-    ipl_grow = 0
-    do ipl = 1, pcom(jj)%npl
-      if (pcom(jj)%plcur(ipl)%gro == "y") then
-        ipl_grow = ipl
-        ! if (pcom(jj)%plg(1)%root_dep < 1.e-6) then
-        if (pcom(jj)%plg(ipl)%root_dep < 1.e-6) then
-          soil(jj)%ly(1)%rtfr = 1
-          return
-        endif
+    if (pcom(j)%plg(ipl)%root_dep < 1.e-6) then
+      pcom(j)%plg(ipl)%rtfr(ly) = 1.
+      return
+    endif
 
-        ! Normalized Root Density = 1.15*exp[-11.7*NRD] + 0.022, where NRD = normalized rooting depth
-        ! Parameters of Normalized Root Density Function from Dwyer et al 19xx
-        a = 1.15
-        b = 11.7
-        c = 0.022
-        d = 0.12029 ! Integral of Normalized Root Distribution Function 
-                    ! from 0 to 1 (normalized depth) = 0.12029
+    ! Normalized Root Density = 1.15*exp[-11.7*NRD] + 0.022, where NRD = normalized rooting depth
+    ! Parameters of Normalized Root Density Function from Dwyer et al 19xx
+    a = 1.15
+    b = 11.7
+    c = 0.022
+    d = 0.12029 ! Integral of Normalized Root Distribution Function 
+                ! from 0 to 1 (normalized depth) = 0.12029
 
-        l = 0
-        k = 0
-        cum_d = 0.
-        cum_rf = 0.
-            sol_thick(:) = 0.
-            rtfr = 0.
+    k = 0
+    !cum_d = 0.
+    cum_rf = 0.
+    rtfr = 0.
 
-        do l = 1, soil(jj)%nly
-          if (l == 1) then
-            sol_thick(l) = soil(jj)%phys(l)%d
-          else  
-            sol_thick(l) = soil(jj)%phys(l)%d - soil(jj)%phys(l-1)%d
-          end if
-            
-          cum_d = cum_d + sol_thick(l)
-          ! if (cum_d >= pcom(jj)%plg(1)%root_dep) cum_rd = pcom(jj)%plg(1)%root_dep
-          if (cum_d >= pcom(jj)%plg(1)%root_dep) cum_rd = pcom(jj)%plg(ipl)%root_dep
-          ! if (cum_d < pcom(jj)%plg(1)%root_dep) cum_rd = cum_d
-          if (cum_d < pcom(jj)%plg(ipl)%root_dep) cum_rd = cum_d
-          ! x1 = (cum_rd - sol_thick(l)) / pcom(jj)%plg(1)%root_dep
-          ! x2 = cum_rd / pcom(jj)%plg(1)%root_dep
-          x1 = (cum_rd - sol_thick(l)) / pcom(jj)%plg(ipl)%root_dep
-          x2 = cum_rd / pcom(jj)%plg(ipl)%root_dep
-              xx1 = -b * x1
-          if (xx1 > 20.) xx1 = 20.
-              xx2 = -b * x2
-              if (xx2 > 20.) xx2 = 20.
-            soil(jj)%ly(l)%rtfr = (a/b*(Exp(xx1) - Exp(xx2)) + c *(x2 - x1))/d
-              xx = cum_rf
-              cum_rf = cum_rf + soil(jj)%ly(l)%rtfr
-              if (cum_rf > 1.) then
-              soil(jj)%ly(l)%rtfr = 1. - xx
-                cum_rf = 1.0
-              end if
-          k = l
-          ! if (cum_rd >= pcom(jj)%plg(1)%root_dep) Exit
-          if (cum_rd >= pcom(jj)%plg(ipl)%root_dep) Exit
-            
-        end do
+    do ly = 1, soil(j)%nly
+      if (soil(j)%phys(ly)%d >= pcom(j)%plg(ipl)%root_dep) then
+        cum_rd = pcom(j)%plg(ipl)%root_dep
+      else
+        cum_rd = soil(j)%phys(ly)%d
+      end if
+      !cum_d = cum_d + soil(j)%phys(ly)%thick
+      !if (cum_d >= pcom(j)%plg(ipl)%root_dep) cum_rd = pcom(j)%plg(ipl)%root_dep
+      !if (cum_d < pcom(j)%plg(ipl)%root_dep) cum_rd = cum_d
+      
+      x1 = (cum_rd - soil(j)%phys(ly)%thick) / pcom(j)%plg(ipl)%root_dep
+      x2 = cum_rd / pcom(j)%plg(ipl)%root_dep
+      xx1 = -b * x1
+      if (xx1 > 20.) xx1 = 20.
+      xx2 = -b * x2
+      if (xx2 > 20.) xx2 = 20.
+      pcom(j)%plg(ipl)%rtfr(ly) = (a/b*(Exp(xx1) - Exp(xx2)) + c *(x2 - x1))/d
+      xx = cum_rf
+      cum_rf = cum_rf + pcom(j)%plg(ipl)%rtfr(ly)
+      if (cum_rf > 1.) then
+        pcom(j)%plg(ipl)%rtfr(ly) = 1. - xx
+        cum_rf = 1.0
+      end if
+      k = ly
+      if (cum_rd >= pcom(j)%plg(ipl)%root_dep) Exit
+         
+    end do
 
-        !!   ensures that cumulative fractional root distribution = 1
-        do l = 1, soil(jj)%nly
-            soil(jj)%ly(l)%rtfr = soil(jj)%ly(l)%rtfr / cum_rf
-            If (l == k) Exit ! exits loop on the same layer as the previous loop
-        end do
-        exit
-      endif
-    enddo
-    ipl = ipl_grow
+    !!   ensures that cumulative fractional root distribution = 1
+    do ly = 1, soil(j)%nly
+      pcom(j)%plg(ipl)%rtfr(ly) = pcom(j)%plg(ipl)%rtfr(ly) / cum_rf
+      if (ly == k) exit ! exits loop on the same layer as the previous loop
+    end do
     
     return
    
-       end subroutine pl_rootfr
+    end subroutine pl_rootfr

--- a/src/plant_init.f90
+++ b/src/plant_init.f90
@@ -101,10 +101,11 @@
         allocate (pcom(j)%plcur(ipl))
         allocate (pl_mass(j)%rsd(ipl))
         allocate (soil1(j)%pl(ipl))
-        !! allocate water uptake by layer
+        !! allocate water uptake and root fraction by layer
         do ipl = 1, pcom(j)%npl
           allocate (pcom(j)%plcur(ipl)%uptake(soil(j)%nly), source = 0.)
           pcom(j)%plcur(ipl)%uptake = 0.
+          allocate (pcom(j)%plg(ipl)%rtfr(soil(j)%nly), source = 0.)
         end do
         !! allocate residue for each plant by soil layer
         do ipl = 1, pcom(j)%npl
@@ -136,32 +137,6 @@
           pl_mass(j)%rsd(ipl)%n = pl_mass(j)%rsd(ipl)%n + 0.42 * pcomdb(icom)%pl(ipl)%rsdin / 10.
           pl_mass(j)%rsd(ipl)%p = pl_mass(j)%rsd(ipl)%p + 0.42 * pcomdb(icom)%pl(ipl)%rsdin / 100.
           pl_mass(j)%rsd_tot = pl_mass(j)%rsd_tot + pl_mass(j)%rsd(ipl)
-          
-          if (bsn_cc%cswat == 2) then
-            !! done in cbn_rsd_decomp subroutine
-            !! metabolic residue
-            !rsd_meta%m = 0.85 * pcomdb(icom)%pl(ipl)%rsdin
-            !rsd_meta%c = 0.357 * pcomdb(icom)%pl(ipl)%rsdin !0.357=0.42*0.85
-            !rsd_meta%n = rsd_meta%c / 10.           !assume 10:1 C:N ratio (EPIC)
-            !rsd_meta%p = rsd_meta%c / 100.   
-            !soil1(j)%meta(1) = soil1(j)%meta(1) + rsd_meta
-            
-            !! structural residue
-            !rsd_str%m = 0.15 * pcomdb(icom)%pl(ipl)%rsdin
-            !rsd_str%c = 0.063 * pcomdb(icom)%pl(ipl)%rsdin   !0.063=0.42*0.15
-            !rsd_str%n = rsd_str%c / 150.             !assume 150:1 C:N ratio (EPIC)
-            !rsd_str%p = rsd_str%c / 1500.   
-            !soil1(j)%str(1) = soil1(j)%str(1) + rsd_str
-          
-            !! lignin residue
-            !soil1(j)%lig(1)%m = soil1(j)%lig(1)%m + 0.8 * rsd_str%m
-            !soil1(j)%lig(1)%c = soil1(j)%lig(1)%c + 0.8 * rsd_str%c              !assume 80% Structural C is lig
-            !soil1(j)%lig(1)%n = soil1(j)%lig(1)%n + 0.2 * rsd_str%n
-            !soil1(j)%lig(1)%p = soil1(j)%lig(1)%p + 0.02 * rsd_str%p
-            
-            !! total residue pools
-            !soil1(j)%rsd(1) = soil1(j)%rsd(1) + rsd_meta + rsd_str
-          end if
           
           ! set heat units to maturity
           ! first compute base0 units for entire year
@@ -366,6 +341,8 @@
             call pl_root_gro(j)
             call pl_seed_gro(j)
             call pl_partition(j, 1)
+            call pl_root_gro(j)
+            call pl_rootfr(j)
           end if
 
         end do   ! ipl loop

--- a/src/plant_module.f90
+++ b/src/plant_module.f90
@@ -19,6 +19,7 @@
          real :: leaf_frac = 0.         !! none             |fraction of above ground tree biomass that is leaf
          real :: root_dep = 0.          !! mm               |root depth
          real :: root_frac = 0.         !! kg/ha            |root fraction of total plant mass
+         real, dimension(:), allocatable :: rtfr   !! none  |root fraction for each plant in community
       end type plant_growth
       
       type plant_mass
@@ -125,7 +126,6 @@
       end type plant_community
       type (plant_community), dimension (:), allocatable :: pcom
       type (plant_community), dimension (:), allocatable :: pcom_init
-      type (plant_growth) :: plgz
       type (plant_mass) :: plmz
       type (plant_mass) :: o_m1, o_m2, o_m3
       type (plant_stress) :: plstrz
@@ -145,5 +145,27 @@
         real :: root = .46      !none   |carbon fraction in roots
       end type plant_carbon
       type (plant_carbon) :: c_frac
-            
+              
+      contains
+
+      !! function to zero plant growth variables for a kill operation
+      subroutine plg_zero (plg)
+        type (plant_growth), intent (inout) :: plg
+        plg%cht = 0.               !! m                |canopy height 
+        plg%lai = 0.               !! m**2/m**2        |leaf area index
+        plg%plet = 0.              !! mm H2O           |actual ET simulated during life of plant
+        plg%plpet = 0.             !! mm H2O           |potential ET simulated during life of plant
+        plg%laimxfr = 0.           !! 
+        plg%laimxfr_p = 0.         !! 
+        plg%hi_adj = 0.            !! (kg/ha)/(kg/ha)  |temperature adjusted harvest index for current time during growing season
+        plg%hi_prev = 0.           !! (kg/ha)/(kg/ha)  |optimal harvest index for current time during growing season
+        plg%olai = 0.              !!                  |leaf area index (0-1) when leaf area decline begins
+        plg%dphu = 0.              !!                  |phu accumulated (0-1) when leaf area decline begins
+        plg%d_senes = 0.           !! days             !days since start of senescence
+        plg%leaf_frac = 0.         !! none             |fraction of above ground tree biomass that is leaf
+        plg%root_dep = 0.          !! mm               |root depth
+        plg%root_frac = 0.         !! kg/ha            |root fraction of total plant mass
+        plg%rtfr(:) = 0.           !! frac             |root fraction for each plant in community
+      end subroutine plg_zero
+      
      end module plant_module

--- a/src/res_control.f90
+++ b/src/res_control.f90
@@ -56,8 +56,8 @@
           !! determine reservoir outflow
           irel = res_dat(idat)%release
           d_tbl => dtbl_res(irel)
-          pvol_m3 = 0.5 * res_ob(jres)%pvol
-          evol_m3 = 0.5 * res_ob(jres)%evol
+          pvol_m3 = res_ob(jres)%pvol
+          evol_m3 = res_ob(jres)%evol
           if (res_wat_d(jres)%area_ha > 1.e-6) then
             dep = wbody%flo / res_wat_d(jres)%area_ha / 10000.     !m = m3 / ha / 10000m2/ha
           else

--- a/src/soil_module.f90
+++ b/src/soil_module.f90
@@ -16,7 +16,6 @@
         real :: prk = 0.         !! mm H2O         percolation from soil layer on current day
         real :: volcr = 0.       !! mm             crack volume for soil layer 
         real :: tillagef = 0.
-        real :: rtfr = 0.        !! none           root fraction
         real :: watp = 0.
         integer :: a_days = 0
         integer :: b_days = 0

--- a/src/soil_nutcarb_init.f90
+++ b/src/soil_nutcarb_init.f90
@@ -25,7 +25,8 @@
       real :: actp = 0.
       real :: solp = 0.
       real :: ssp = 0.
-      real :: psp = 0.                  !              |
+      real :: psp = 0.  
+      real :: tot_mass                  !kg/ha      |total mass of the soil layer
 
       !! suppress unused variable warning
       if (isol < 0) continue
@@ -108,27 +109,29 @@
 
         !! Set Stable pool based on dynamic coefficient
         if (bsn_cc%sol_P_model == 1) then  !! From White et al 2009 
-            !! convert to concentration for ssp calculation
-            actp = soil1(ihru)%mp(ly)%act / wt1
-            solp = soil1(ihru)%mp(ly)%lab / wt1
-            !! estimate Total Mineral P in this soil based on data from sharpley 2004
-            ssp = 25.044 * (actp + solp)** (-0.3833)
-            !!limit SSP Range
-            if (ssp > 7.) ssp = 7.
-            if (ssp < 1.) ssp = 1.            
-            soil1(ihru)%mp(ly)%sta = ssp * (soil1(ihru)%mp(ly)%act + soil1(ihru)%mp(ly)%lab)
-         else
+          !! convert to concentration for ssp calculation
+          actp = soil1(ihru)%mp(ly)%act / wt1
+          solp = soil1(ihru)%mp(ly)%lab / wt1
+          !! estimate Total Mineral P in this soil based on data from sharpley 2004
+          ssp = 25.044 * (actp + solp)** (-0.3833)
+          !!limit SSP Range
+          if (ssp > 7.) ssp = 7.
+          if (ssp < 1.) ssp = 1.            
+          soil1(ihru)%mp(ly)%sta = ssp * (soil1(ihru)%mp(ly)%act + soil1(ihru)%mp(ly)%lab)
+        else
           !! the original code
           soil1(ihru)%mp(ly)%sta = 4. * soil1(ihru)%mp(ly)%act
-       end if
+        end if
       end do
 
       !! set initial organic pools - originally by Zhang
       do ly = 1, nly
 
-        !initialize total soil organic pool - no litter
-        !kg/ha = mm * t/m3 * m/1,000 mm * 1,000 kg/t * 10,000 m2/ha
-        soil1(ihru)%tot(ly)%m = 10000. * soil(ihru)%phys(ly)%thick * soil(ihru)%phys(ly)%bd
+        !!initialize total soil organic pool - no litter
+        !!kg/ha = mm * t/m3 * m/1,000 mm * 1,000 kg/t * 10,000 m2/ha
+        tot_mass = 10000. * soil(ihru)%phys(ly)%thick * soil(ihru)%phys(ly)%bd
+        !! total mass of soil organic matter - cbn in %, and assume SOM is 58% carbon
+        soil1(ihru)%tot(ly)%m = tot_mass * (soil1(ihru)%cbn(ly) / 100.) / 0.58
         soil1(ihru)%tot(ly)%c = soil1(ihru)%tot(ly)%m * soil1(ihru)%cbn(ly) / 100.
         soil1(ihru)%tot(ly)%n = soil1(ihru)%tot(ly)%c / 10.     !assume 10:1 C:N ratio
         soil1(ihru)%tot(ly)%p = soil1(ihru)%tot(ly)%c / 100.    !assume 100:1 C:P ratio
@@ -138,7 +141,7 @@
           if (solt_db(isolt)%fr_hum_act < 1.e-9) solt_db(isolt)%fr_hum_act = .02
           frac_hum_active = solt_db(isolt)%fr_hum_act
         
-          !initialize oringinal SWAT active and stable organic pools (from EPIC)
+          !initialize original SWAT active and stable organic pools (from EPIC)
           !initialize active humus pool
           soil1(ihru)%hact(ly)%m = frac_hum_active * soil1(ihru)%tot(ly)%m
           soil1(ihru)%hact(ly)%c = frac_hum_active * soil1(ihru)%tot(ly)%c
@@ -153,42 +156,56 @@
         end if
         
         if (bsn_cc%cswat == 2) then
-          !initialize CENTURY organic pools
-          !set soil humus fractions for CENTURY from DSSAT
+          !!initialize CENTURY organic pools - set soil humus fractions for CENTURY from DSSAT
           frac_hum_microb = 0.02
           frac_hum_slow = 0.54
           frac_hum_passive = 0.44
- 
-          !initialize passive humus pool
-          ! if (ly == 1) then
-            ! soil1(ihru)%hp(ly) = soil_org_z
-            ! soil1(ihru)%hs(ly) = soil_org_z
-            ! soil1(ihru)%microb(ly) = soil_org_z
-          ! else
 
-            soil1(ihru)%hp(ly)%m = frac_hum_passive * soil1(ihru)%tot(ly)%m
-            soil1(ihru)%hp(ly)%c = frac_hum_passive * soil1(ihru)%tot(ly)%c
-            soil1(ihru)%hp(ly)%n = soil1(ihru)%hp(ly)%c / 10.                       !assume 10:1 C:N ratio
-            soil1(ihru)%hp(ly)%p = soil1(ihru)%hp(ly)%c / 80.                       !assume 80:1 C:P ratio
+          !!initialize passive humus pool
+          soil1(ihru)%hp(ly)%m = frac_hum_passive * soil1(ihru)%tot(ly)%m
+          soil1(ihru)%hp(ly)%c = frac_hum_passive * soil1(ihru)%tot(ly)%c
+          soil1(ihru)%hp(ly)%n = soil1(ihru)%hp(ly)%c / 10.                   !assume 10:1 C:N ratio
+          soil1(ihru)%hp(ly)%p = soil1(ihru)%hp(ly)%c / 80.                   !assume 80:1 C:P ratio
               
-            !initialize slow humus pool
-            soil1(ihru)%hs(ly)%m = frac_hum_slow * soil1(ihru)%tot(ly)%m
-            soil1(ihru)%hs(ly)%c = frac_hum_slow * soil1(ihru)%tot(ly)%c
-            soil1(ihru)%hs(ly)%n = soil1(ihru)%hs(ly)%c / 10.                       !assume 10:1 C:N ratio
-            soil1(ihru)%hs(ly)%p = soil1(ihru)%hs(ly)%c / 80.                       !assume 80:1 C:P ratio
+          !!initialize slow humus pool
+          soil1(ihru)%hs(ly)%m = frac_hum_slow * soil1(ihru)%tot(ly)%m
+          soil1(ihru)%hs(ly)%c = frac_hum_slow * soil1(ihru)%tot(ly)%c
+          soil1(ihru)%hs(ly)%n = soil1(ihru)%hs(ly)%c / 10.                   !assume 10:1 C:N ratio
+          soil1(ihru)%hs(ly)%p = soil1(ihru)%hs(ly)%c / 80.                   !assume 80:1 C:P ratio
               
-            !initialize microbial pool
-            soil1(ihru)%microb(ly)%m = frac_hum_microb * soil1(ihru)%tot(ly)%m
-            soil1(ihru)%microb(ly)%c = frac_hum_microb * soil1(ihru)%tot(ly)%c
-            soil1(ihru)%microb(ly)%n = soil1(ihru)%microb(ly)%c / 8.                !assume 8:1 C:N ratio
-            soil1(ihru)%microb(ly)%p = soil1(ihru)%microb(ly)%c / 80.               !assume 80:1 C:P ratio
-          ! endif
+          !!initialize microbial pool
+          soil1(ihru)%microb(ly)%m = frac_hum_microb * soil1(ihru)%tot(ly)%m
+          soil1(ihru)%microb(ly)%c = frac_hum_microb * soil1(ihru)%tot(ly)%c
+          soil1(ihru)%microb(ly)%n = soil1(ihru)%microb(ly)%c / 8.            !assume 8:1 C:N ratio
+          soil1(ihru)%microb(ly)%p = soil1(ihru)%microb(ly)%c / 80.           !assume 80:1 C:P ratio
+            
+          !! metabolic residue
+          soil1(ihru)%meta(ly) = plt_mass_z
+          !soil1(ihru)%meta(ly)%m = 0.85 * soil1(ihru)%tot(ly)%m
+          !soil1(ihru)%meta(ly)%c = 0.357 * soil1(ihru)%tot(ly)%c              !0.357=0.42*0.85
+          !soil1(ihru)%meta(ly)%n = soil1(ihru)%meta(ly)%c / 10.               !assume 10:1 C:N ratio (EPIC)
+          !soil1(ihru)%meta(ly)%p = soil1(ihru)%meta(ly)%c / 100.   
+            
+          !! structural residue
+          soil1(ihru)%str(ly) = plt_mass_z
+          !soil1(ihru)%str(ly)%m = 0.15 * soil1(ihru)%tot(ly)%m
+          !soil1(ihru)%str(ly)%c = 0.063 * soil1(ihru)%tot(ly)%c               !0.063=0.42*0.15
+          !soil1(ihru)%str(ly)%n = soil1(ihru)%str(ly)%c / 150.                !assume 150:1 C:N ratio (EPIC)
+          !soil1(ihru)%str(ly)%p = soil1(ihru)%str(ly)%c / 1500.
+          
+          !! lignin residue
+          soil1(ihru)%lig(ly) = plt_mass_z
+          !soil1(ihru)%lig(ly)%m = 0.8 * soil1(ihru)%str(ly)%m
+          !soil1(ihru)%lig(ly)%c = 0.8 * soil1(ihru)%str(ly)%c                 !assume 80% Structural C is lig
+          !soil1(ihru)%lig(ly)%n = 0.2 * soil1(ihru)%str(ly)%n
+          !soil1(ihru)%lig(ly)%p = 0.02 * soil1(ihru)%str(ly)%p
+            
+        end if
 
           soil1(ihru)%tot(ly) = soil1(ihru)%str(ly) + soil1(ihru)%meta(ly) + soil1(ihru)%hs(ly) + soil1(ihru)%hp(ly) + soil1(ihru)%microb(ly)
           soil1(ihru)%seq(ly) = soil1(ihru)%hs(ly) + soil1(ihru)%hp(ly) + soil1(ihru)%microb(ly)
 
-        end if
-      end do   !! ens soil layer loop 
+      end do   !! end soil layer loop 
 
       return
       end subroutine soil_nutcarb_init

--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -52,7 +52,7 @@
       use constituent_mass_module
       use output_ls_pesticide_module
       use water_body_module
-      use water_allocation_module
+      !use water_allocation_module
       !use reservoir_data_module
       
       implicit none
@@ -80,7 +80,6 @@
       integer :: curyr = 0           !              |
       integer :: mo = 0              !              |
       integer :: day_mo = 0          !              |
-      integer :: iwallo = 0
       integer :: imallo = 0
       integer :: ires = 0
       
@@ -232,15 +231,6 @@
               call actions (j, iob, id)
             end do
           end do
-
-          !! allocate water for water rights objects
-          if (db_mx%wallo_db > 0) then
-            do iwallo = 1, db_mx%wallo_db
-              !! if a channel is not an object, call at beginning of day
-              j = iwallo    ! to avoid a compiler warning
-              if (wallo(iwallo)%cha_ob == "n") call wallo_control (j)
-            end do
-          end if
 
           !! allocate manure to appropriate demand objects
           if (db_mx%mallo_db > 0) then


### PR DESCRIPTION

This pull request introduces a new subroutine for surface residue decomposition, refactors how root fractions and residue mass are handled across several plant and soil management routines, and improves numerical stability in decomposition calculations. It also updates the control flow in the main HRU routine to integrate these changes, and cleans up some variable naming and function usage for clarity and correctness.

**Key changes:**

### 1. Surface Residue Decomposition and Integration
- Added new subroutine `cbn_surfrsd_decomp` to handle daily surface residue decomposition and mineralization of nitrogen and phosphorus, improving modularity and clarity of surface vs. soil residue processing. (`src/cbn_surfres_decomp.f90`)
- Updated `hru_control` to call `cbn_surfrsd_decomp` when `bsn_cc%cswat == 2`, ensuring correct sequencing of surface and soil residue decomposition routines. (`src/hru_control.f90`)

### 2. Root Fraction and Residue Handling Refactor
- Changed calls to `pl_rootfr` to include the HRU index as an argument, ensuring root fractions are updated for the correct HRU. (`src/mgt_harvtuber.f90`, `src/mgt_killop.f90`) [[1]](diffhunk://#diff-708bccd28cdd1d76eebb3b07c40f8277c480374cf444972bb5406d0602786419L50-R55) [[2]](diffhunk://#diff-283d908e55a56915e48258e6599b812fd0bdcef78c193e8cf02546b1bf52f0b3L26-R29)
- Updated logic for allocating dead roots to soil residue pools to use `pcom(j)%plg(ipl)%rtfr(ly)` instead of previous approaches, improving accuracy and consistency. (`src/mgt_harvtuber.f90`, `src/mgt_killop.f90`) [[1]](diffhunk://#diff-708bccd28cdd1d76eebb3b07c40f8277c480374cf444972bb5406d0602786419L50-R55) [[2]](diffhunk://#diff-283d908e55a56915e48258e6599b812fd0bdcef78c193e8cf02546b1bf52f0b3L42-R43)
- Replaced direct resetting of plant growth variables with a call to `plg_zero` for better encapsulation. (`src/mgt_killop.f90`)

### 3. Numerical Stability and Error Prevention
- Moved underflow-prevention checks for residue pools in `cbn_rsd_decomp` to after decomposition calculations, and applied similar checks in the new surface residue routine. (`src/cbn_rsd_decomp.f90`, `src/cbn_surfres_decomp.f90`) [[1]](diffhunk://#diff-3ec383fad2bb30e5208522754b6aa3bb36c38264462ec6226ebcaa282dcb8889L81-L87) [[2]](diffhunk://#diff-3ec383fad2bb30e5208522754b6aa3bb36c38264462ec6226ebcaa282dcb8889R125-R130) [[3]](diffhunk://#diff-08916301229e13b996abe788dbc017729aa2b97b87a4af663fb931fecf527bacR1-R156)
- Adjusted threshold for checking meaningful carbon content in soil organic pools from `1.e-12` to `1.e-6` to avoid division by very small numbers and potential instability. (`src/cbn_rsd_decomp.f90`)

### 4. Control Flow and Function Call Clean-up
- Removed unused or misplaced calls such as `pl_rootfr` in `hru_control`, and updated residue decomposition logic to better reflect the intended model flow. (`src/hru_control.f90`) [[1]](diffhunk://#diff-98d017aee2f97704b9e5c35356a2ec3893354dd4371e673a409af900e75d20a8L448-L450) [[2]](diffhunk://#diff-98d017aee2f97704b9e5c35356a2ec3893354dd4371e673a409af900e75d20a8L370-R385)
- Updated subroutine argument lists and variable names for clarity and consistency, including typo fixes (e.g., "aoil" instead of "soil"). (`src/hru_control.f90`)

### 5. Miscellaneous Improvements
- Improved logic for updating ammonium and nitrate pools in `cbn_zhang2` for greater correctness and clarity. (`src/cbn_zhang2.f90`)
- Refactored and clarified variable names in `nut_orgnc2` for better readability and maintainability. (`src/nut_orgnc2.f90`)

These changes collectively improve the modularity, correctness, and robustness of the residue decomposition and nutrient cycling routines in the model.