### PR TITLE
Copilot/move readcio read statement

### DIFF
--- a/src/proc_bsn.f90
+++ b/src/proc_bsn.f90
@@ -8,6 +8,8 @@
       external :: basin_print_codes_read, basin_prm_default, basin_read_cc, basin_read_objs, &
                   basin_read_prm, carbon_coef_read, co2_read, readcio_read, time_read
       
+      call readcio_read
+
 !!!  open file to print all output files that are written
       call open_output_file(9000, "files_out.out")
       write (9000,*) "files_out.out - OUTPUT FILES WRITTEN"      
@@ -16,8 +18,6 @@
      write (9001,*) "DIAGNOSTICS.OUT FILE" 
 !!!  open drainage areas output file
      call open_output_file(9004, "area_calc.out", 80000)
-
-      call readcio_read
                 
       call basin_read_cc
       call basin_read_objs

--- a/src/proc_bsn.f90
+++ b/src/proc_bsn.f90
@@ -17,6 +17,7 @@
 !!!  open drainage areas output file
      call open_output_file(9004, "area_calc.out", 80000)
 
+      call readcio_read
                 
       call basin_read_cc
       call basin_read_objs
@@ -25,8 +26,6 @@
       !if (time%step > 0) then
         time%dtm = 1440. / time%step
       !end if
-      
-      call readcio_read
              
       call basin_read_prm
       call basin_prm_default


### PR DESCRIPTION
This pull request makes a minor change to the initialization sequence in the `proc_bsn` subroutine. The main update is moving the call to `readcio_read` earlier in the process, ensuring that input/output configuration is read before opening output files and proceeding with other initialization steps. This change helps guarantee that file I/O settings are properly established before any files are accessed.

Key change:

* Moved the call to `readcio_read` to occur before opening output files and removed its later invocation, ensuring I/O configuration is set up at the correct point in `proc_bsn`. [[1]](diffhunk://#diff-ddac69fdf7920d57fcd10fa1cf0adf563159767bef038b8cb0ba8ee77dff5f19R11-R12) [[2]](diffhunk://#diff-ddac69fdf7920d57fcd10fa1cf0adf563159767bef038b8cb0ba8ee77dff5f19L29-L30)