### PR TITLE
Adjust first layer depth to 20 cm based on conditions for single or m…

### DIFF
--- a/src/soil_db_read.f90
+++ b/src/soil_db_read.f90
@@ -75,7 +75,12 @@
                 soildb(isol)%ly(j)%ec, soildb(isol)%ly(j)%cal, soildb(isol)%ly(j)%ph
             if (eof < 0) exit
           end do
-          if (soildb(isol)%ly(1)%z < 20.) soildb(isol)%ly(1)%z = 20.
+          !! if the first layer is less than 20 cm, adjust to 20 cm if only one layer or second layer is greater than 20 cm
+          if (soildb(isol)%ly(1)%z < 20.) then
+            if (soildb(isol)%s%nly == 1 .or. soildb(isol)%ly(2)%z > 20.) then
+                soildb(isol)%ly(1)%z = 20.
+            end if
+          end if
         end do
         exit
         enddo


### PR DESCRIPTION
This pull request refines the logic for adjusting the thickness of the first soil layer in the `soil_db_read` subroutine. The update ensures that the first layer's thickness is only set to 20 cm under specific conditions, improving the accuracy of soil profile initialization.

**Soil layer adjustment logic:**

* Updated the condition so that the first layer's thickness (`z`) is set to 20 cm only if there is a single layer or if the second layer's thickness is greater than 20 cm, instead of always forcing it when the first layer is less than 20 cm.…ultiple layers