### PR TITLE
Fix wetland yearly and average annual outputs

### DIFF
--- a/src/wetland_output.f90
+++ b/src/wetland_output.f90
@@ -60,8 +60,8 @@
           wet_in_a(j) = wet_in_a(j) + wet_in_y(j)
           wet_out_a(j) = wet_out_a(j) + wet_out_y(j)
           wet_wat_a(j) = wet_wat_a(j) + wet_wat_y(j)
-          wet_in_y(j)%flo = wet_in_y(j)%flo / 12.
-          wet_out_y(j)%flo = wet_out_y(j)%flo / 12.
+          !wet_in_y(j)%flo = wet_in_y(j)%flo / 12.
+          !wet_out_y(j)%flo = wet_out_y(j)%flo / 12.
           if (pco%res%y == "y") then
             write (2550,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_y(j), wet(j), &
             wet_in_y(j), wet_out_y(j)

--- a/src/wetland_output.f90
+++ b/src/wetland_output.f90
@@ -70,15 +70,15 @@
                 wet_wat_y(j), wet(j), wet_in_y(j), wet_out_y(j)
               end if
           end if
-          !wet_in_y(j) = resmz
-          !wet_out_y(j) = resmz
-          !wet_wat_y(j) = wbodz
+          wet_in_y(j) = resmz
+          wet_out_y(j) = resmz
+          wet_wat_y(j) = wbodz
        end if
 
 !!!!! average annual print
         if (time%end_sim == 1 .and. pco%res%a == "y") then
-          wet_in_a(j) = wet_in_y(j) / time%yrs_prt
-          wet_out_a(j) = wet_out_y(j) / time%yrs_prt
+          wet_in_a(j) = wet_in_a(j) / time%yrs_prt
+          wet_out_a(j) = wet_out_a(j) / time%yrs_prt
           wet_wat_a(j) = wet_wat_a(j) / time%yrs_prt
           write (2551,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_a(j), wet(j), &
           wet_in_a(j), wet_out_a(j)


### PR DESCRIPTION
Two bugs in `wetland_output.f90` caused incorrect `flo_in `and `flo_out `values in the yearly (`wetland_yr`) and average annual (`wetland_aa`) outputs:

1. Yearly output (`wetland_yr`): `flo_in `and `flo_out `were incorrectly divided by 12 before being written. Additionally, the yearly accumulators (`wet_in_y`, `wet_out_y`, `wet_wat_y`) were not reset after writing, causing values to carry over into subsequent years.

1. Average annual output (`wetland_aa`): `flo_in `and `flo_out `were averaged using the yearly accumulator (`wet_in_y`, `wet_out_y`) instead of the simulation-long accumulator (`wet_in_a`, `wet_out_a`), producing wrong average annual values.