### PR TITLE
Bug/Fix: Divide-by-zero crash in climate_control.f90 when pet_sum is zero

### DIFF
--- a/src/cli_initwgn.f90
+++ b/src/cli_initwgn.f90
@@ -244,7 +244,11 @@
       end do
 
       wgn_pms(iwgn)%pcp_an = summm_p
-      wgn_pms(iwgn)%ppet_an = summm_p / summm_pet
+      if (summm_pet > 1.e-3) then
+        wgn_pms(iwgn)%ppet_an = summm_p / summm_pet
+      else
+        wgn_pms(iwgn)%ppet_an = summm_p / 1.e-3
+      end if
       wgn_pms(iwgn)%tmp_an = (summx_t + summn_t) / 24.
 
       !! calculate initial temperature of soil layers

--- a/src/climate_control.f90
+++ b/src/climate_control.f90
@@ -215,7 +215,11 @@
         iwgn = wst(iwst)%wco%wgn
         wgn_pms(iwgn)%precip_sum = wgn_pms(iwgn)%precip_sum + wst(iwst)%weat%precip - wgn_pms(iwgn)%precip_mce(ppet_mce)
         wgn_pms(iwgn)%pet_sum = wgn_pms(iwgn)%pet_sum + wst(iwst)%weat%pet - wgn_pms(iwgn)%pet_mce(ppet_mce)
-        wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / max(wgn_pms(iwgn)%pet_sum, 1.e-6)
+        if (wgn_pms(iwgn)%pet_sum > 1.e-6) then
+          wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / wgn_pms(iwgn)%pet_sum
+        else
+          wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / 1.e-6
+        end if
         wgn_pms(iwgn)%precip_mce(ppet_mce) = wst(iwst)%weat%precip
         wgn_pms(iwgn)%pet_mce(ppet_mce) = wst(iwst)%weat%pet
         

--- a/src/climate_control.f90
+++ b/src/climate_control.f90
@@ -215,7 +215,7 @@
         iwgn = wst(iwst)%wco%wgn
         wgn_pms(iwgn)%precip_sum = wgn_pms(iwgn)%precip_sum + wst(iwst)%weat%precip - wgn_pms(iwgn)%precip_mce(ppet_mce)
         wgn_pms(iwgn)%pet_sum = wgn_pms(iwgn)%pet_sum + wst(iwst)%weat%pet - wgn_pms(iwgn)%pet_mce(ppet_mce)
-        wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / wgn_pms(iwgn)%pet_sum
+        wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / max(wgn_pms(iwgn)%pet_sum, 1.e-6)
         wgn_pms(iwgn)%precip_mce(ppet_mce) = wst(iwst)%weat%precip
         wgn_pms(iwgn)%pet_mce(ppet_mce) = wst(iwst)%weat%pet
         

--- a/src/climate_control.f90
+++ b/src/climate_control.f90
@@ -218,7 +218,7 @@
         if (wgn_pms(iwgn)%pet_sum > 1.e-6) then
           wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / wgn_pms(iwgn)%pet_sum
         else
-          wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / 1.e-6
+          wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / 1.e-6 !fix
         end if
         wgn_pms(iwgn)%precip_mce(ppet_mce) = wst(iwst)%weat%precip
         wgn_pms(iwgn)%pet_mce(ppet_mce) = wst(iwst)%weat%pet

--- a/src/climate_control.f90
+++ b/src/climate_control.f90
@@ -215,10 +215,12 @@
         iwgn = wst(iwst)%wco%wgn
         wgn_pms(iwgn)%precip_sum = wgn_pms(iwgn)%precip_sum + wst(iwst)%weat%precip - wgn_pms(iwgn)%precip_mce(ppet_mce)
         wgn_pms(iwgn)%pet_sum = wgn_pms(iwgn)%pet_sum + wst(iwst)%weat%pet - wgn_pms(iwgn)%pet_mce(ppet_mce)
+        !! update precip/pet ratio using 30 day moving sums
         if (wgn_pms(iwgn)%pet_sum > 1.e-6) then
           wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / wgn_pms(iwgn)%pet_sum
         else
-          wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / 1.e-6 !fix
+          !! use a minimum PET sum to avoid divide by zero
+          wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / 1.e-6
         end if
         wgn_pms(iwgn)%precip_mce(ppet_mce) = wst(iwst)%weat%precip
         wgn_pms(iwgn)%pet_mce(ppet_mce) = wst(iwst)%weat%pet


### PR DESCRIPTION

> I encountered a divide-by-zero crash when running the model for cold regions (winter). In such scenarios, the Potential Evapotranspiration (PET) can be exactly `0` for consecutive days, causing `pet_sum` to be `0`. 
> 
> In `climate_control.f90` (around line 225), there is no protective check before dividing by `pet_sum`, which leads to a crash:
> ```fortran
> wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / wgn_pms(iwgn)%pet_sum
> ```
> 
> **Proposed Fix:**
> To prevent the crash while maintaining the hydrometeorological logic (where P/PET represents a wetness index that should spike during winter precipitation with near-zero evaporation), I recommend adding an `if` statement to check `pet_sum` before division. If `pet_sum` is extremely small, we can divide by a tiny number to preserve the extreme moisture surplus logic in cold, snow-driven climates without causing a crash or precision mismatch errors.
> 
> Here is the proposed safe replacement for that line:
> 
> ```fortran
> if (wgn_pms(iwgn)%pet_sum > 1.e-6) then
>   wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / wgn_pms(iwgn)%pet_sum
> else
>   wgn_pms(iwgn)%p_pet_rto = wgn_pms(iwgn)%precip_sum / 1.e-6
> end if
> ```