### PR TITLE
Bug fixed: rtfr should be reset to 0 at the beginning of pl_rootfr.f90 and ly should be set to 1

### DIFF
--- a/src/output_landscape_module.f90
+++ b/src/output_landscape_module.f90
@@ -97,7 +97,7 @@
         real :: no3atmo = 0.            !kg N/ha        |nitrate added to the soil from atmospheric deposition
         real :: nh4atmo = 0.            !kg N/ha        |ammonia added to the soil from atmospheric deposition
         real :: nuptake = 0.            !kg N/ha        |plant nitrogen uptake
-        real :: puptake = 0.            !kg N/ha        |plant phosphorus uptake
+        real :: puptake = 0.            !kg P/ha        |plant phosphorus uptake
         real :: gwsoiln = 0.            !kg N/ha        |nitrate added to the soil from the aquifer (rtb gwflow)
         real :: gwsoilp = 0.            !kg P/ha        |Phos added to the soil from the aquifer (rtb gwflow)
       end type output_nutbal
@@ -138,7 +138,7 @@
         real :: act_sta_n = 0.          !kg N/ha        |nitrogen moving from active organic pool to stable pool
         real :: org_lab_p = 0.          !kg P/ha        |phosphorus moving from the organic pool to labile pool
         real :: rsd_hs_c = 0.           !kg C/ha        |amt of carbon moving from the fresh org (residue) to soil slow humus 
-        real :: rsd_nitorg_n = 0.       !kg P/ha        |nitrogen moving from the fresh organic pool (residue) to nitrate
+        real :: rsd_nitorg_n = 0.       !kg N/ha        |nitrogen moving from the fresh organic pool (residue) to nitrate
         real :: rsd_laborg_p = 0.       !kg P/ha        |phosphorus moving from the fresh organic pool (residue) to the labile (80%)
                                                         !   and org (20%) pools
       end type output_nutcarb_cycling
@@ -196,7 +196,7 @@
         real :: sedminp = 0.        !kg P/ha        |mineral phosphorus leaving the landscape transported in sediment
         real :: tileno3 = 0.        !kg N/ha        |nitrate NO3 in tile flow
         real :: lchlabp = 0.        !kg P/ha        |soluble P (labile) leaching past bottom soil layer
-        real :: tilelabp = 0.       !kg N/ha        |soluble P (labile) NO3 in tile flow
+        real :: tilelabp = 0.       !kg P/ha        |soluble P (labile) in tile flow
         real :: satexn = 0.         !kg N/ha        | amt of NO3-N in saturation excess surface runoff in HRU for the day
       end type output_losses
       

--- a/src/pl_rootfr.f90
+++ b/src/pl_rootfr.f90
@@ -14,7 +14,7 @@
     real :: cum_rf = 0.               !            |
     real :: x1 = 0.                   !            |
     real :: x2 = 0.                   !            |
-    integer, intent (in) :: j         !none               |HRU number
+    integer, intent (in) :: j         !none        |HRU number
     integer :: k = 0                  !            |
     integer :: ly = 0                 !none        |number of soil layer that manure applied
     real :: a = 0.                    !            |
@@ -26,8 +26,11 @@
     real :: xx2 = 0.                  !            |
     real :: xx = 0.                   !            |
     
+    ly = 0
+    pcom(j)%plg(ipl)%rtfr = 0. ! First, reset all layer's root fractions to zero
+    
     if (pcom(j)%plg(ipl)%root_dep < 1.e-6) then
-      pcom(j)%plg(ipl)%rtfr(ly) = 1.
+      pcom(j)%plg(ipl)%rtfr(1) = 1.
       return
     endif
 


### PR DESCRIPTION
+ Bug fixed:
In `pl_rootfr.f90`, 
```
if (pcom(j)%plg(ipl)%root_dep < 1.e-6) then
      pcom(j)%plg(ipl)%rtfr(ly) = 1.
      return
endif
```
`ly` is assigned before this routine. So, `ly` is likely to exceed the layer range of the current HRU. So, the `ly` should be set to 1.

Besides,  `pcom(j)%plg(ipl)%rtfr` should be reset to 0.

One more thing, I suggest defining this subroutine as `pl_rootfr(j, iplant)`, just like the subroutine `mgt_killop(j, iplant)`. **In this PR, I didn't make the change to the subroutine's arguments. Please review this suggestion.**

+ Typos corrected in `output_landscape_module.f90)`