### PR TITLE
Several improvements to gwflow

### DIFF
--- a/src/gwflow_canl.f90
+++ b/src/gwflow_canl.f90
@@ -146,8 +146,8 @@
                   if(Q < 0) then !mass is leaving the cell --> canal
                     do s=1,gw_nsolute !loop through the solutes
                       solmass(s) = Q * gwsol_state(cell_id)%solute(s)%conc !g
-                      if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
-                        solmass(s) = gwsol_state(cell_id)%solute(s)%mass
+                      if(-solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
+                        solmass(s) = -gwsol_state(cell_id)%solute(s)%mass
                       endif
                     enddo
                   else !mass entering the cell from the canal (i.e., from the channel that provides the canal water)

--- a/src/gwflow_canl_out.f90
+++ b/src/gwflow_canl_out.f90
@@ -82,9 +82,9 @@
               if (gw_solute_flag == 1) then
                 if(Q < 0) then !mass is leaving the cell --> canal
                   do s=1,gw_nsolute !loop through the solutes
-                    solmass(s) = Q * gwsol_state(cell_id)%solute(s)%conc !g
-                    if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
-                      solmass(s) = gwsol_state(cell_id)%solute(s)%mass
+                    solmass(s) = Q * gwsol_state(cell_id)%solute(s)%conc !g, negative: leaving the aquifer
+                    if(-solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
+                      solmass(s) = -gwsol_state(cell_id)%solute(s)%mass
                     endif
                   enddo
                 else !mass entering the cell from the canal (i.e., from the channel that provides the canal water)

--- a/src/gwflow_gwsw.f90
+++ b/src/gwflow_gwsw.f90
@@ -103,10 +103,10 @@
             if(Q < 0) then !mass leaving the cell (aquifer --> channel)
               do s=1,gw_nsolute !loop through the solutes
                 solmass(s) = Q * gwsol_state(cell_id)%solute(s)%conc !g
-                if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
-                  solmass(s) = gwsol_state(cell_id)%solute(s)%mass
+                if(-solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
+                  solmass(s) = -gwsol_state(cell_id)%solute(s)%mass
                 endif
-                gwsol_ss(cell_id)%solute(s)%gwsw = solmass(s)
+                gwsol_ss(cell_id)%solute(s)%gwsw = gwsol_ss(cell_id)%solute(s)%gwsw + solmass(s)
                 gwsol_ss_sum(cell_id)%solute(s)%gwsw = gwsol_ss_sum(cell_id)%solute(s)%gwsw + solmass(s)
               enddo  
               !add solute mass to channel
@@ -189,7 +189,7 @@
               endif
               !store for mass balance calculations (in gwflow_simulate)
               do s=1,gw_nsolute !loop through the solutes
-                gwsol_ss(cell_id)%solute(s)%swgw = solmass(s)
+                gwsol_ss(cell_id)%solute(s)%swgw = gwsol_ss(cell_id)%solute(s)%swgw + solmass(s)
                 gwsol_ss_sum(cell_id)%solute(s)%gwsw = gwsol_ss_sum(cell_id)%solute(s)%gwsw + solmass(s)
               enddo
             endif

--- a/src/gwflow_module.f90
+++ b/src/gwflow_module.f90
@@ -20,7 +20,8 @@
       integer :: grid_nrow = 0                                !number of rows in structured grid
       integer :: grid_ncol = 0                                !number of columns in structured grid
       integer, dimension (:,:), allocatable :: cell_id_usg    !usg cell number, for cell in structured grid (array)
-      integer, dimension (:), allocatable :: cell_id_list     !usg cell number, for cell in structured grid (list)
+      integer, dimension (:), allocatable :: cell_id_list     !original cell number to valid cell id, for cell in structured grid (list)
+      integer, dimension (:), allocatable :: cell_id_init_list !valid cell id to original cell number, for cell in structured grid (list)
       integer, dimension (:,:), allocatable :: grid_status    !cell status for structured grid
       integer, dimension (:,:), allocatable :: grid_int       !generic array for reading in values for structured grid
       real, dimension (:,:), allocatable :: grid_val          !generic array for reading in values for structured grid

--- a/src/gwflow_ppag.f90
+++ b/src/gwflow_ppag.f90
@@ -57,7 +57,8 @@
           
           !check for available groundwater in the cell
           if(gw_state(cell_id)%head > gw_state(cell_id)%botm) then !if water table is above bedrock
-            gwvol_avail = ((gw_state(cell_id)%head-gw_state(cell_id)%botm) * gw_state(cell_id)%area) * gw_state(cell_id)%spyd !m3
+            ! gwvol_avail = ((gw_state(cell_id)%head-gw_state(cell_id)%botm) * gw_state(cell_id)%area) * gw_state(cell_id)%spyd !m3
+            gwvol_avail = gw_state(cell_id)%stor
           else
             gwvol_avail = 0.
           endif
@@ -75,7 +76,8 @@
           trn_unmet = trn_unmet + gwvol_unmet
           
           !save the pumping volume (m3), for use in gwflow_simulate
-          gw_ss(cell_id)%ppag = gwvol_removed * (-1) !m3 negative = leaving the aquifer
+          gw_state(cell_id)%stor = gw_state(cell_id)%stor + gwvol_removed * (-1) !update available groundwater in the cell
+          gw_ss(cell_id)%ppag = gw_ss(cell_id)%ppag + gwvol_removed * (-1) !m3 negative = leaving the aquifer
           gw_ss_sum(cell_id)%ppag = gw_ss_sum(cell_id)%ppag + (gwvol_removed * (-1))
           
           !sum the pumping for the current HRU

--- a/src/gwflow_ppex.f90
+++ b/src/gwflow_ppex.f90
@@ -42,8 +42,8 @@
                 Q = gw_pumpex_rates(i,j)
                 if(Q.ge.gw_state(cell_id)%stor) then
                   Q = gw_state(cell_id)%stor
-                  gw_state(cell_id)%stor = gw_state(cell_id)%stor - Q
                 endif
+                gw_state(cell_id)%stor = gw_state(cell_id)%stor - Q
                 gw_ss(cell_id)%ppex = gw_ss(cell_id)%ppex - Q !negative = leaving the aquifer
                 gw_ss_sum(cell_id)%ppex = gw_ss_sum(cell_id)%ppex - Q 
                 !if chemical transport simulated, calculate the mass of N and P removed via pumping

--- a/src/gwflow_read.f90
+++ b/src/gwflow_read.f90
@@ -57,7 +57,7 @@
       real :: dist_y = 0.             !          |
       real :: min_dist = 0.           !          |
       real :: distance = 0.           !          |
-      real :: gw_cell_volume = 0.     !          |
+      !real :: gw_cell_volume = 0.     !          |
       !input file numbers
       integer :: in_gw = 0            !          |
       integer :: in_hru_cell = 0      !          |
@@ -307,6 +307,12 @@
             cell_id_list(count) = ncell
           endif
         enddo
+      enddo
+      allocate (cell_id_init_list(ncell))
+      do i=1,grid_nrow*grid_ncol
+          if (cell_id_list(i) > 0) then
+              cell_id_init_list(cell_id_list(i))=i
+          endif
       enddo
       !second: !allocate general array of cell attributes
       allocate (gw_state(ncell))
@@ -1353,7 +1359,7 @@
       
         !include no3 and p (default)
         gw_nsolute = 2
-        gwsol_nm(1) = 'no3'
+        gwsol_nm(1) = 'no3-n' ! change from no3 to no3-n, to keep consistent with auto-generated gwflow.solutes
         gwsol_nm(2) = 'p'
         
         !determine which other solutes should be included
@@ -1409,8 +1415,11 @@
         if(grid_type == "structured") then
           !read one array at a time
           do s=1,gw_nsolute
-            read(in_gw,*) header
+            read(in_gw,*) header ! since we specified gw_nsolute as 
             read(in_gw,*) read_type
+            if(header /= gwsol_nm(s)) then ! TODO In the auto-generated gwflow.solutes, we should add a line to indicate how many solutes are included.
+                write(9003,*) "Warning: ", gwsol_nm(s), " is not found in gwflow.solutes, will use 0 by default."
+            endif    
             if(read_type == "single") then
               read(in_gw,*) single_value
               grid_val = single_value
@@ -1418,6 +1427,8 @@
               do i=1,grid_nrow
                 read(in_gw,*) (grid_val(i,j),j=1,grid_ncol)
               enddo
+            else
+              grid_val = 0  ! In case the input format of gwflow.solutes is not correct!
             endif
             do i=1,grid_nrow
               do j=1,grid_ncol
@@ -2290,22 +2301,30 @@
       endif
       gw_rech = 0.
       
-      !set groundwater head to initial head, for each grid cell
+      !set groundwater head to initial head, and set initial storage for each grid cell
       do i=1,ncell
         gw_state(i)%head = gw_state(i)%init
+        if(gw_state(i)%stat.gt.0) then
+          if(gw_state(i)%head > gw_state(i)%botm) then
+            gw_state(i)%stor = ((gw_state(i)%head - gw_state(i)%botm) * gw_state(i)%area) * gw_state(i)%spyd
+          else
+            gw_state(i)%stor = 0.
+          endif
+        endif
       enddo
       
       !set solute mass for each grid cell
       if (gw_solute_flag == 1) then
         do i=1,ncell
           if(gw_state(i)%stat.gt.0) then
-            if(gw_state(i)%head > gw_state(i)%botm) then
-              gw_cell_volume = gw_state(i)%area * (gw_state(i)%head-gw_state(i)%botm) * gw_state(i)%spyd !m3 of groundwater
-            else
-              gw_cell_volume = 0.
-            endif
+            !if(gw_state(i)%head > gw_state(i)%botm) then
+            !  gw_cell_volume = gw_state(i)%area * (gw_state(i)%head-gw_state(i)%botm) * gw_state(i)%spyd !m3 of groundwater
+            !else
+            !  gw_cell_volume = 0.
+            !endif
             do s=1,gw_nsolute !loop through solutes
-              gwsol_state(i)%solute(s)%mass = gw_cell_volume * gwsol_state(i)%solute(s)%conc !m3 * g/m3 = g
+              !gwsol_state(i)%solute(s)%mass = gw_cell_volume * gwsol_state(i)%solute(s)%conc !m3 * g/m3 = g
+              gwsol_state(i)%solute(s)%mass = gw_state(i)%stor * gwsol_state(i)%solute(s)%conc !m3 * g/m3 = g
             enddo
           endif
         enddo

--- a/src/gwflow_resv.f90
+++ b/src/gwflow_resv.f90
@@ -92,10 +92,10 @@
                 if(Q < 0) then !mass leaving the cell (aquifer --> reservoir)
                   do s=1,gw_nsolute !loop through the solutes
                     solmass(s) = Q * gwsol_state(cell_id)%solute(s)%conc !g
-                    if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
-                      solmass(s) = gwsol_state(cell_id)%solute(s)%mass
+                    if(-solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
+                      solmass(s) = -gwsol_state(cell_id)%solute(s)%mass
                     endif
-                    gwsol_ss(cell_id)%solute(s)%resv = solmass(s)
+                    gwsol_ss(cell_id)%solute(s)%resv = gwsol_ss(cell_id)%solute(s)%resv + solmass(s)
                     gwsol_ss_sum(cell_id)%solute(s)%resv = gwsol_ss_sum(cell_id)%solute(s)%resv + solmass(s)
                   enddo    
                   !add solute to reservoir
@@ -181,7 +181,7 @@
                   endif
                   !store for mass balance calculations (in gwflow_simulate)
                   do s=1,gw_nsolute !loop through the solutes
-                    gwsol_ss(cell_id)%solute(s)%resv = solmass(s)
+                    gwsol_ss(cell_id)%solute(s)%resv = gwsol_ss(cell_id)%solute(s)%resv + solmass(s)
                     gwsol_ss_sum(cell_id)%solute(s)%resv = gwsol_ss_sum(cell_id)%solute(s)%resv + solmass(s)
                   enddo
                 endif

--- a/src/gwflow_satx.f90
+++ b/src/gwflow_satx.f90
@@ -42,9 +42,13 @@
               satx_count = satx_count + 1 !track the number of saturated cells (for output)
               satx_depth = gw_state(cell_id)%head - gw_state(cell_id)%elev !height above ground surface
               satx_volume = (gw_state(cell_id)%area * satx_depth) * gw_state(cell_id)%spyd !m3 of groundwater above ground surface 
+              if (satx_volume  >= gw_state(cell_id)%stor) then !can only remove what is there
+                satx_volume = gw_state(cell_id)%stor
+              endif
+              gw_state(cell_id)%stor = gw_state(cell_id)%stor + (satx_volume * (-1)) !update available groundwater in the cell
               
               !store for water balance calculations (in gwflow_simulate)
-              gw_ss(cell_id)%satx = satx_volume * (-1) !negative = leaving the aquifer
+              gw_ss(cell_id)%satx = gw_ss(cell_id)%satx + (satx_volume * (-1)) !negative = leaving the aquifer
               gw_ss_sum(cell_id)%satx = gw_ss_sum(cell_id)%satx + (satx_volume * (-1))
               
               !store for channel object (positive value = water added to channel)
@@ -58,7 +62,7 @@
                   if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
                     solmass(s) = gwsol_state(cell_id)%solute(s)%mass
                   endif
-                  gwsol_ss(cell_id)%solute(s)%satx = solmass(s) * (-1) !negative = leaving the aquifer
+                  gwsol_ss(cell_id)%solute(s)%satx = gwsol_ss(cell_id)%solute(s)%satx + (solmass(s) * (-1)) !negative = leaving the aquifer
                   gwsol_ss_sum(cell_id)%solute(s)%satx = gwsol_ss_sum(cell_id)%solute(s)%satx + (solmass(s)*(-1))
                 enddo
                 !add solute mass to channel

--- a/src/gwflow_simulate.f90
+++ b/src/gwflow_simulate.f90
@@ -163,19 +163,21 @@
                      
       !record file
       write(out_gw,*) 'gwflow subroutine called:',time%yrc,time%day
-      
+
       
       
       !1. calculate the available volume of groundwater (m3) in each cell ---------------------------------------------
-      do i=1,ncell
-        if(gw_state(i)%stat.gt.0) then
-          if(gw_state(i)%head > gw_state(i)%botm) then
-            gw_state(i)%stor = ((gw_state(i)%head - gw_state(i)%botm) * gw_state(i)%area) * gw_state(i)%spyd
-          else
-            gw_state(i)%stor = 0.
-          endif
-        endif
-      enddo
+      ! The groundwater storage should be intialized once at the begining of the entire simulation,
+      !   the following code was moved to gwflow_read.f90.
+      !do i=1,ncell
+      !  if(gw_state(i)%stat.gt.0) then
+      !    if(gw_state(i)%head > gw_state(i)%botm) then
+      !      gw_state(i)%stor = ((gw_state(i)%head - gw_state(i)%botm) * gw_state(i)%area) * gw_state(i)%spyd
+      !    else
+      !      gw_state(i)%stor = 0.
+      !    endif
+      !  endif
+      !enddo
       
       
 
@@ -416,8 +418,8 @@
 
               !update storage and head for the cell
               stor_change = (Q + gw_ss(i)%totl) * gw_time_step !change in storage (m3)
-              gw_state(i)%stor = gw_state(i)%stor + stor_change !new storage (m3)
-              sat_change = stor_change / (gw_state(i)%spyd * gw_state(i)%area) !change in saturated thickness (m3)
+              gw_state(i)%stor = gw_state(i)%vbef + stor_change !new storage (m3)
+              sat_change = stor_change / (gw_state(i)%spyd * gw_state(i)%area) !change in saturated thickness (m)
               gw_state(i)%hnew = gw_state(i)%head + sat_change !new groundwater head (m)
               
             elseif(gw_state(i)%stat == 2) then !constant head cell                 

--- a/src/gwflow_soil.f90
+++ b/src/gwflow_soil.f90
@@ -11,9 +11,6 @@
       
       implicit none
 
-      
-      
-      
       external :: sq_crackvol
       integer, intent (in) :: hru_id     !       |hru number
       integer :: k = 0                   !       |counter
@@ -32,7 +29,6 @@
       real :: layer_transfer = 0.        !       |amount of water and solute transferred to the soil layer
       real :: hru_area_m2 = 0.           !m2     |surface area of the hru
       
-
 
       !area of the HRU in m2
       hru_area_m2 = ob(hru_id)%area_ha * 10000.    
@@ -63,6 +59,10 @@
               hru_Q = (hru_soilz - vadose_z) * poly_area * gw_state(cell_id)%spyd !m3 of groundwater to transfer to the soil profile 
 
               !store for water balance calculations (in gwflow_simulate)
+              if (hru_Q  >= gw_state(cell_id)%stor) then !can only remove what is there
+                hru_Q = gw_state(cell_id)%stor
+              endif
+              gw_state(cell_id)%stor = gw_state(cell_id)%stor + (hru_Q*(-1)) !update available groundwater in the cell
               gw_ss(cell_id)%soil = gw_ss(cell_id)%soil + (hru_Q*(-1)) !negative = leaving the aquifer
               gw_ss_sum(cell_id)%soil = gw_ss_sum(cell_id)%soil + (hru_Q*(-1))
 
@@ -74,7 +74,7 @@
                   if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
                     solmass(s) = gwsol_state(cell_id)%solute(s)%mass
                   endif
-                  gwsol_ss(cell_id)%solute(s)%soil = gwsol_ss(cell_id)%solute(s)%soil + solmass(s) * (-1) !negative = leaving the aquifer
+                  gwsol_ss(cell_id)%solute(s)%soil = gwsol_ss(cell_id)%solute(s)%soil + (solmass(s)*(-1)) !negative = leaving the aquifer
                   gwsol_ss_sum(cell_id)%solute(s)%soil = gwsol_ss_sum(cell_id)%solute(s)%soil + (solmass(s)*(-1))
                 enddo  
               endif !end solutes
@@ -108,7 +108,7 @@
                 layer_transfer = (hru_Q*layer_fraction) / hru_area_m2 * 1000. !m3 --> mm
                 soil(hru_id)%phys(jj)%st = soil(hru_id)%phys(jj)%st + layer_transfer !mm
                 gwsoilq(hru_id) = gwsoilq(hru_id) + layer_transfer !store for hru output
-              if (gw_solute_flag == 1) then
+                if (gw_solute_flag == 1) then
                   do s=1,gw_nsolute !loop through the solutes
                     layer_transfer = (solmass(s)*layer_fraction) / 1000. / ob(hru_id)%area_ha !g --> kg/ha
                     hru_soil(hru_id,jj,s) = hru_soil(hru_id,jj,s) + layer_transfer !kg/ha (mass added to soil profile in nut_nlch, nut_solp, salt_lch, cs_lch)

--- a/src/gwflow_tile.f90
+++ b/src/gwflow_tile.f90
@@ -54,8 +54,8 @@
               if(Q > gw_state(cell_id)%stor) then
                 Q = gw_state(cell_id)%stor
               endif
-              gw_state(cell_id)%stor = gw_state(cell_id)%stor - Q !update available groundwater in the cell 
-              gw_ss(cell_id)%tile = Q * (-1) !leaving aquifer
+              gw_state(cell_id)%stor = gw_state(cell_id)%stor + (Q*(-1)) !update available groundwater in the cell 
+              gw_ss(cell_id)%tile = gw_ss(cell_id)%tile + (Q*(-1)) !leaving aquifer
               gw_ss_sum(cell_id)%tile = gw_ss_sum(cell_id)%tile + (Q*(-1)) !leaving aquifer
               
               !add water to channel
@@ -68,7 +68,7 @@
                   if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
                     solmass(s) = gwsol_state(cell_id)%solute(s)%mass
                   endif
-                  gwsol_ss(cell_id)%solute(s)%tile = solmass(s) * (-1) !leaving aquifer
+                  gwsol_ss(cell_id)%solute(s)%tile = gwsol_ss(cell_id)%solute(s)%tile + (solmass(s)*(-1)) !leaving aquifer
                   gwsol_ss_sum(cell_id)%solute(s)%tile = gwsol_ss_sum(cell_id)%solute(s)%tile + (solmass(s)*(-1)) !leaving aquifer
                 enddo  
                 !add solute to channel

--- a/src/gwflow_wetl.f90
+++ b/src/gwflow_wetl.f90
@@ -63,8 +63,9 @@
               gw_inflow = wet_area * wet_k * ((wt-wet_stage)/wet_thick(ires)) !m3/day
               !check against available groundwater storage (m3) in the grid cell
               if(gw_state(cell_id)%head > gw_state(cell_id)%botm) then !if water table is above bedrock
-                gwvol_avail = ((gw_state(cell_id)%head - gw_state(cell_id)%botm) * &
-                                gw_state(cell_id)%area) * gw_state(cell_id)%spyd !m3
+                !gwvol_avail = ((gw_state(cell_id)%head - gw_state(cell_id)%botm) * &
+                !                gw_state(cell_id)%area) * gw_state(cell_id)%spyd !m3
+                gwvol_avail = gw_state(cell_id)%stor
               else
                 gwvol_avail = 0.
               endif
@@ -73,6 +74,7 @@
                 gw_inflow = gwvol_avail
               endif
               !include in groundwater source-sink array (will be removed in gwflow_simulate)
+              gw_state(cell_id)%stor = gw_state(cell_id)%stor + (gw_inflow*(-1))
               gw_ss(cell_id)%wetl = gw_ss(cell_id)%wetl + (gw_inflow*(-1)) !m3 negative = leaving the aquifer
               gw_ss_sum(cell_id)%wetl = gw_ss_sum(cell_id)%wetl + (gw_inflow*(-1))
               !add groundwater inflow to wetland; include in wetland water balance
@@ -89,8 +91,8 @@
                   if(solmass(s) > gwsol_state(cell_id)%solute(s)%mass) then !can only remove what is there
                     solmass(s) = gwsol_state(cell_id)%solute(s)%mass
                   endif
-                  gwsol_ss(cell_id)%solute(s)%wetl = solmass(s)
-                  gwsol_ss_sum(cell_id)%solute(s)%wetl = gwsol_ss_sum(cell_id)%solute(s)%wetl + solmass(s)
+                  gwsol_ss(cell_id)%solute(s)%wetl = gwsol_ss(cell_id)%solute(s)%wetl + (solmass(s)*(-1))
+                  gwsol_ss_sum(cell_id)%solute(s)%wetl = gwsol_ss_sum(cell_id)%solute(s)%wetl + (solmass(s)*(-1))
                 enddo
                 !add solute mass to wetland object
                 !no3


### PR DESCRIPTION
This PR includes several improvements to gwflow. Please review if my understanding and revisions are correct. Thank you! @celray 

+ Initialize `gw_state()%stor` in `gwflow_read.f90`
The groundwater storage can be initialized with the groundwater head in `gwflow_read.f90`.

+ Add a variable(`cell_id_init_list`) to store the valid cell ID to the original cell number for cells in the structured grid (list). It's convenient to debug.

+ In `gwflow_simulate.f90`, the groundwater storage cannot be calculated at the beginning using the groundwater head. That's because the simulations of the following subroutines ( `gwflow_rech`, `gwflow_gwet`, etc.) rely on storage that was updated during the channel-related subroutines (`gwflow_gwsw`, etc.) on the last day. Therefore, my understanding is that groundwater storage should be updated in various gwflow-related subroutines, and the groundwater head and the final storage can only be updated in the `gwflow_simulate` for channel-related subroutines on the current day, and in other subroutines on the next day.
Based on this, I revised all gwflow-related subroutines to make sure:
  + The groundwater storage will not be repeatedly calculated by the groundwater head.
  + The groundwater storage is updated in each separate gwflow-related subroutine.
  + The storage changes, as well as the solute mass, have correct positive or negative values.

+ The default `gwflow.solutes` file content should be revised in SWAT+Editor (i.e., the function `write_solutes(self, file_name='gwflow.solutes')`).
The third line is `1.0           number of transport time steps for flow time step`. But in SWAT+, the number is defined as an integer. For gfortran, this causes a crash, and ifort/ifx does not. But it's better to keep consistent between the generated `gwflow.solutes` file and the SWAT+ source code.

+ Add checks when reading initial concentrations from the `gwflow.solutes` 
In this PR, I just revised the reading code to check if the value `header` equals `gwsol_nm(s)`.
Actually, according to the standard plaintext style of SWAT+, I suggest adding a counter number to indicate how many solutes are included in the `gwflow.solutes`. 