### PR TITLE
fix: correct outflow subtraction from storage in reservoir

### DIFF
--- a/src/res_hydro.f90
+++ b/src/res_hydro.f90
@@ -133,8 +133,8 @@
               end select
               ht2%flo = ht2%flo + (wbody%flo - b_lo) / d_tbl%act(iac)%const / nstep
               ht2%flo = max(0.,ht2%flo)
-              wbody%flo = max(0.,wbody%flo - ht2%flo)    ! & jga-jj 6-3-2025
-              vol = wbody%flo
+              !wbody%flo = max(0.,wbody%flo - ht2%flo)    ! & jga-jj 6-3-2025 ! 07.04.2026 removed: this is alrready done in res_control.f90 so double substraction if set here
+              !vol = wbody%flo
               
             case ("dyrt")
               !! release based on drawdown days + percentage of principal volume
@@ -234,7 +234,7 @@
                 end do
               endif
               res_h = vol / wsa1 !m
-              wbody%flo = vol !m3
+              !wbody%flo = vol !m3  ! removed: this is alrready done in res_control.f90 so double substraction if set here
               !iweir = d_tbl%act_typ(iac)
               !ht2%flo = ht2%flo + res_weir(iweir)%c * res_weir(iweir)%w * hgt_above ** res_weir(iweir)%k / nstep   !m3/s
               !ht2%flo = ht2%flo + max(0.,ht2%flo)

--- a/src/wetland_control.f90
+++ b/src/wetland_control.f90
@@ -188,7 +188,9 @@
         evol_m3 = wet_ob(j)%evol
         call conditions (j, irel)
         call res_hydro (j, irel, pvol_m3, evol_m3)
-      end if 
+        !! subtract outflow from wetland storage (similar to res_control)
+        wet(j)%flo = max(0., wet(j)%flo - ht2%flo)
+      end if
       
       !! surface runoff from wetland is discharge (outflow) ht2
       surfq(j) = ht2%flo / wsa1 !mm


### PR DESCRIPTION
This PR fixes a water balance error where reservoir storage is decremented twice by the same outflow volume, causing a silent and significant water loss for reservoir using the `days` or `weir` release options.

### Problem
`res_hydro` is called by both `res_control` (reservoirs) and `wetland_control` (wetlands). It computes the daily outflow `ht2%flo`.

In `res_control.f90` line 171, outflow is subtracted from storage unconditionally after `res_hydro` returns, for all release options:
```
! res_control.f90:171
res(jres)%flo = res(jres)%flo - ht2%flo
```
However, in` res_hydro.f90`, two release cases also update `wbody%flo` directly:

`days` case (lines 136-137):

```
! res_hydro.f90:136-137
wbody%flo = max(0.,wbody%flo - ht2%flo)    ! & jga-jj 6-3-2025
vol = wbody%flo

```
`weir` case (line 237):

```

! res_hydro.f90:237
wbody%flo = vol !m3
```

Since `wbody => res(jres)` is a Fortran pointer (same memory), `res_control:171` then subtracts outflow **a second time**. At quasi-steady state this causes approximately **50% of inflow to disappear**, with no seepage, evaporation, or storage increase to account for it. This means than a small reservoir anywhere in the watershed routing network could silently consume half of its incoming flow, with the loss propagating downstream and causing a significant underestimation of streamflow at the watershed outlet.

### Fix
`res_hydro.f90`: comment out the `wbody%flo` updates in the `days` (lines 136-137) and `weir` (line 237) cases, since `res_control.f90:171` already handles the subtraction for all release options.

`wetland_control.f90`: add an explicit storage decrement after call `res_hydro` (line 190):


```
! wetland_control.f90 - after line 190
wet(j)%flo = max(0., wet(j)%flo - ht2%flo)
```
Wetlands share the same `res_hydro` subroutine but `wetland_control' has no equivalent of `res_control:171`  and without this line, wetland storage would never be decremented by outflow when using decision table release options other than days or weir.

