### PR TITLE
Refactor erosion and pesticide modules to include biomass and ground cover

### DIFF
--- a/src/ch_pesticide_module.f90
+++ b/src/ch_pesticide_module.f90
@@ -123,20 +123,20 @@
         type (ch_pesticide_processes), intent (in) :: ch1
         real, intent (in) :: const
         type (ch_pesticide_processes) :: ch2
-          ch2%tot_in = ch1%tot_in
-          ch2%sol_out = ch1%sol_out
-          ch2%sor_out = ch1%sor_out
-          ch2%react = ch1%react
-          ch2%metab = ch1%metab
-          ch2%volat = ch1%volat
-          ch2%settle = ch1%settle
-          ch2%resus = ch1%resus
-          ch2%difus = ch1%difus
-          ch2%react_bot = ch1%react_bot
-          ch2%metab_bot = ch1%metab_bot
-          ch2%bury = ch1%bury
-          ch2%water = ch1%water
-          ch2%benthic = ch1%benthic
+          ch2%tot_in = const * ch1%tot_in
+          ch2%sol_out = const * ch1%sol_out
+          ch2%sor_out = const * ch1%sor_out
+          ch2%react = const * ch1%react
+          ch2%metab = const * ch1%metab
+          ch2%volat = const * ch1%volat
+          ch2%settle = const * ch1%settle
+          ch2%resus = const * ch1%resus
+          ch2%difus = const * ch1%difus
+          ch2%react_bot = const * ch1%react_bot
+          ch2%metab_bot = const * ch1%metab_bot
+          ch2%bury = const * ch1%bury
+          ch2%water = const * ch1%water
+          ch2%benthic = const * ch1%benthic
       end function chpest_ave
       
       end module ch_pesticide_module

--- a/src/ero_cfactor.f90
+++ b/src/ero_cfactor.f90
@@ -38,15 +38,12 @@
       integer :: j = 0              !none          |HRU number
       integer :: ipl = 0            !none          |sequential plant number
       integer :: idp = 0            !none          |plant number in data file - pldb
-      real :: c = 0.                !              |
-      real :: ab_gr_t = 0.          !tons          |above ground biomass of each plant
-      real :: rsd_pctcov = 0.       !              |percent of cover by residue
+      real :: c = 0.                !              |usle c factor
+      real :: ab_gr_t = 0.          !tons          |total above ground biomass of plant community
       real :: rsd_covfact = 0.      !              |residue cover factor
-      real :: can_covfact = 0.      !              |canopy cover factor
-      real :: can_frcov = 0.        !              |fraction of canopy cover
-      real :: rsd_sumfac = 0.       !              |sum of residue cover factor by plant
-      real :: grnd_sumfac = 0.      !              |ground cover factor for each plant
-      real :: grnd_covfact = 0.     !              |sum of plant ground cover factor by plant
+      real :: rsd_sumfac = 0.       !tons          |sum of residue cover factor by plant
+      real :: grcov_frac = 0.       !frac          |fraction of ground cover factor for all plants
+      real :: bio_covfact = 0.      !              |growing biomass factor
       real :: cover = 0.            !kg/ha         |soil cover - sum of residue and biomass
       
       j = ihru
@@ -66,73 +63,27 @@
           end if
         end if
       else
-        !! new method using residue and biomass cover
-        grnd_sumfac = 0.
-        rsd_sumfac = pldb(idp)%rsd_pctcov * (pl_mass(j)%rsd_tot%m +1.) / 1000.
-        do ipl = 1, pcom(j)%npl
-          idp = pcom(j)%plcur(ipl)%idplt
-          if (pl_mass(j)%ab_gr(ipl)%m > 1.e-6) then
-            ab_gr_t = pl_mass(j)%ab_gr(ipl)%m / 1000.
-            grnd_sumfac = grnd_sumfac + 100. * pldb(idp)%usle_c / ab_gr_t
-          end if
-        end do
-        if (grnd_sumfac < 1.e-6) then
-          grnd_sumfac = 10.
-        end if
         
-        rsd_pctcov = 100. * (1. - exp_w(-rsd_sumfac))
-        rsd_pctcov = amin1 (100., rsd_pctcov)
-        rsd_pctcov = max (0., rsd_pctcov)
-        rsd_covfact = exp_w (-pcom(j)%rsd_covfac * rsd_pctcov)
-        
-        can_frcov = amin1 (1., pcom(j)%lai_sum)
-        can_frcov = amin1 (1., pcom(j)%lai_sum / 3.)
-        can_covfact = 1. - can_frcov * exp_w(-.328 * pcom(j)%cht_mx)
-        can_covfact = amin1 (1., can_covfact)
-        can_covfact = max (0., can_covfact)
-        
-        grnd_sumfac = Min (10., grnd_sumfac)
-        grnd_covfact = (1. - exp_w(-grnd_sumfac))
-        grnd_covfact = amin1 (1., grnd_covfact)
-        grnd_covfact = max (0., grnd_covfact)
-        
-        !grnd_covfact = 1.34 + 0.225 * log(pldb(idp)%usle_c)
-        !grnd_covfact = amin1 (1., grnd_covfact)
-        !grnd_covfact = max (0., grnd_covfact)
-        c = Max(1.e-10, rsd_covfact * can_covfact * grnd_covfact)
-        
-        !! newer method using residue and biomass cover
-        rsd_sumfac = (pl_mass(j)%rsd_tot%m +1.) / 1000.
-        grnd_sumfac = 0.
-        can_covfact = 10000.
-        do ipl = 1, pcom(j)%npl
-          idp = pcom(j)%plcur(ipl)%idplt
-          ab_gr_t = pl_mass(j)%ab_gr(ipl)%m / 1000.
-          grnd_sumfac = grnd_sumfac + ab_gr_t
-          !! grnd_covfact = grnd_covfact + pldb(idp)%usle_c * ab_gr_t / (ab_gr_t + exp(1.175 - 1.748 * ab_gr_t))
-          can_covfact = amin1 (can_covfact, pcom(j)%plg(ipl)%cht)
-        end do
-        !grnd_covfact = grnd_sumfac / (grnd_sumfac + exp(1.175 - 1.748 * grnd_sumfac))
+        !! new method using residue and biomass cover - from APEX
+        rsd_sumfac = (pl_mass(j)%rsd_tot%m + 1.) / 1000.
         rsd_covfact = exp_w(-bsn_prm%rsd_covco * rsd_sumfac)
         
-        can_frcov = amin1 (1., pcom(j)%lai_sum / 3.)
-        can_covfact = 1. - can_frcov * exp_w(-.328 * pcom(j)%cht_mx)
+        ab_gr_t = pl_mass(j)%ab_gr_com%m / 1000.
+        grcov_frac = ab_gr_t / (ab_gr_t + exp_w(1.175 - 1.748 * ab_gr_t))
+        bio_covfact = 1. - grcov_frac * exp_w(-.328 * pcom(j)%cht_mx)
+        bio_covfact = Max(1.e-10, bio_covfact)
+        bio_covfact = Min(1., bio_covfact)
         
-        grnd_covfact = exp_w(-pldb(idp)%usle_c * grnd_sumfac)
-        !! bio_covfac = 1. - grnd_covfact * exp(-0.1 * can_covfact)
-        c = Max(1.e-10, rsd_covfact * grnd_covfact)  ! * can_covfact)
+        c = Max(1.e-10, rsd_covfact * bio_covfact)
         
         !! erosion output variables
         ero_output(j)%ero_d%c = c
         ero_output(j)%ero_d%rsd_m = pl_mass(j)%rsd_tot%m
-        ero_output(j)%ero_d%rsd_pctcov = rsd_pctcov
-        ero_output(j)%ero_d%rsd_cfac = rsd_covfact
-        ero_output(j)%ero_d%can_lai3 = can_frcov
-        ero_output(j)%ero_d%canhgt = pcom(j)%cht_mx
-        ero_output(j)%ero_d%can_cfac = can_covfact
+        ero_output(j)%ero_d%grcov_frac = grcov_frac
+        ero_output(j)%ero_d%rsd_covfact = rsd_covfact
+        ero_output(j)%ero_d%bio_covfact = bio_covfact
         
       end if
-
       
       usle_cfac(ihru) = c
       

--- a/src/erosion_module.f90
+++ b/src/erosion_module.f90
@@ -14,11 +14,9 @@
         real :: p = 0.              !           |usle p factor
         real :: c = 0.              !           |usle c factor
         real :: rsd_m = 0.          !kg/ha      |surface residue mass
-        real :: rsd_pctcov = 0.     !%          |surface residue percent ground cover
-        real :: rsd_cfac = 0.       !           |residue c subfactor
-        real :: can_lai3 = 0.       !           |canopy cover - lai/3.
-        real :: canhgt = 0.         !m          |canopy height
-        real :: can_cfac = 0.       !           |canopy c subfactor
+        real :: grcov_frac = 0.     !frac       |ground cover fraction
+        real :: rsd_covfact = 0.    !           |residue cover factor
+        real :: bio_covfact = 0.    !           |growing biomass factor
       end type erosion_output_variables
 
       type erosion_output
@@ -41,11 +39,9 @@
         character (len=12)  :: p          =  "   p_factor"
         character (len=12)  :: c          =  "   c_factor"
         character (len=12)  :: rsd_m      =  "      rsd_m"
-        character (len=12)  :: rsd_pctcov =  " rsd_pctcov"
-        character (len=12)  :: rsd_cfac   =  "   rsd_cfac"
-        character (len=12)  :: can_lai3   =  "   can_lai3"
-        character (len=12)  :: canhgt     =  "   can_hgt"
-        character (len=12)  :: can_cfac   =  "   can_cfac"
+        character (len=12)  :: grcov_frac =  " grcov_frac"
+        character (len=12)  :: rsd_covfact   =  " rsd_covfact"
+        character (len=12)  :: bio_covfact   =  " bio_covfact"
       end type erosion_output_header      
       type (erosion_output_header) :: ero_hdr
       
@@ -62,11 +58,9 @@
         character (len=12)  :: p          =  "           "
         character (len=12)  :: c          =  "           "
         character (len=12)  :: rsd_m      =  "      kg/ha"
-        character (len=12)  :: rsd_pctcov =  "    percent"
-        character (len=12)  :: rsd_cfac   =  "           "
-        character (len=12)  :: can_lai3   =  "           "
-        character (len=12)  :: canhgt     =  "          m"
-        character (len=12)  :: can_cfac   =  "           "
+        character (len=12)  :: grcov_frac =  "       frac"
+        character (len=12)  :: rsd_covfact   =  "           "
+        character (len=12)  :: bio_covfact   =  "           "
       end type erosion_header_units      
       type (erosion_header_units) :: ero_hdr_units
    
@@ -100,11 +94,10 @@ contains
         ero_3%ls = ero_1%ls + ero_2%ls
         ero_3%p = ero_1%p + ero_2%p
         ero_3%rsd_m = ero_1%rsd_m + ero_2%rsd_m
-        ero_3%rsd_pctcov = ero_1%rsd_pctcov + ero_2%rsd_pctcov
-        ero_3%rsd_cfac = ero_1%rsd_cfac + ero_2%rsd_cfac
-        ero_3%can_lai3 = ero_1%can_lai3 + ero_2%can_lai3
-        ero_3%canhgt = ero_1%canhgt + ero_2%canhgt
-        ero_3%can_cfac = ero_1%can_cfac + ero_2%can_cfac
+        ero_3%grcov_frac = ero_1%grcov_frac + ero_2%grcov_frac
+        ero_3%rsd_covfact = ero_1%rsd_covfact + ero_2%rsd_covfact
+        ero_3%bio_covfact = ero_1%bio_covfact + ero_2%bio_covfact
+        ero_3%c = ero_1%c + ero_2%c
       end function ero_add
                           
       !! divide erosion outputs by number of events
@@ -122,11 +115,10 @@ contains
         ero_2%ls = ero_1%ls / const
         ero_2%p = ero_1%p / const
         ero_2%rsd_m = ero_1%rsd_m / const
-        ero_2%rsd_pctcov = ero_1%rsd_pctcov / const
-        ero_2%rsd_cfac = ero_1%rsd_cfac / const
-        ero_2%can_lai3 = ero_1%can_lai3 / const
-        ero_2%canhgt = ero_1%canhgt / const
-        ero_2%can_cfac = ero_1%can_cfac / const
+        ero_2%grcov_frac = ero_1%grcov_frac / const
+        ero_2%rsd_covfact = ero_1%rsd_covfact / const
+        ero_2%bio_covfact = ero_1%bio_covfact / const
+        ero_2%c = ero_1%c / const
       end function ero_divide
       
       end module erosion_module 


### PR DESCRIPTION
This pull request refactors the calculation and representation of erosion cover factors in the erosion module. It updates the approach for computing the USLE C factor by implementing a newer method based on residue and biomass cover, and it simplifies and modernizes the associated data structures and output variables. The changes improve clarity and consistency in variable naming and calculation methods.

**Erosion cover factor calculation and variable updates:**

* Replaced the old residue/canopy/ground cover method in `ero_cfactor` with a new approach based on total above-ground biomass and residue cover, aligning with the APEX model. This introduces new variables such as `grcov_frac`, `rsd_covfact`, and `bio_covfact`, and removes several legacy variables and calculations. [[1]](diffhunk://#diff-4a38e5cc7126164b82a08654a5b24b1c4b1a0eba34fd6d71b3561a5069eb5106L41-R46) [[2]](diffhunk://#diff-4a38e5cc7126164b82a08654a5b24b1c4b1a0eba34fd6d71b3561a5069eb5106L69-L136)
* Updated the `erosion_output_variables` type and related headers/units in `erosion_module.f90` to use the new variables (`grcov_frac`, `rsd_covfact`, `bio_covfact`) and removed obsolete ones (`rsd_pctcov`, `rsd_cfac`, `can_lai3`, `canhgt`, `can_cfac`). [[1]](diffhunk://#diff-a8dfeff035094cd8a8d41a3aa42522797cbae4d1b5fc5a523bbf0f0c625b677dL17-R19) [[2]](diffhunk://#diff-a8dfeff035094cd8a8d41a3aa42522797cbae4d1b5fc5a523bbf0f0c625b677dL44-R44) [[3]](diffhunk://#diff-a8dfeff035094cd8a8d41a3aa42522797cbae4d1b5fc5a523bbf0f0c625b677dL65-R63)

**Erosion output aggregation functions:**

* Modified the `ero_add` and `ero_divide` functions to aggregate and average the new erosion output variables, ensuring consistency with the updated data structures. [[1]](diffhunk://#diff-a8dfeff035094cd8a8d41a3aa42522797cbae4d1b5fc5a523bbf0f0c625b677dL103-R100) [[2]](diffhunk://#diff-a8dfeff035094cd8a8d41a3aa42522797cbae4d1b5fc5a523bbf0f0c625b677dL125-R121)

**Other model consistency improvements:**

* Updated the `chpest_ave` function in `ch_pesticide_module.f90` to multiply all process variables by a constant, rather than simply copying them, improving the flexibility of pesticide process averaging.