### PR TITLE
Remove C-Farm specific nutrient management code from subroutines

### DIFF
--- a/src/hru_control.f90
+++ b/src/hru_control.f90
@@ -533,11 +533,6 @@
               call nut_orgn
             end if
         
-            !! C-Farm (Armen) c and organic n in runoff
-            if (bsn_cc%cswat == 1) then
-              call nut_orgnc
-            end if
-      
             !! SWAT-C Xuesong -- c and organic n in runoff
             if (bsn_cc%cswat == 2 .or. bsn_cc%cswat == 3) then
               call nut_orgnc2

--- a/src/mgt_newtillmix_wet.f90
+++ b/src/mgt_newtillmix_wet.f90
@@ -212,9 +212,6 @@
           end if
         end do
     
-        !if (bsn_cc%cswat == 1) then
-        !    call mgt_tillfactor(jj,bmix,emix,dtil)
-        !end if
       end if
 
       return

--- a/src/pl_burnop.f90
+++ b/src/pl_burnop.f90
@@ -61,14 +61,7 @@
         hpc_d(j)%emit_c = hpc_d(j)%emit_c + pl_burn%c
         
         !! burn all surface (layer 1) residue and humus components
-        if (bsn_cc%cswat == 1) then
-          !! const carbon (bsn_cc%cswat == 1)
-          pl_burn = fire_db(iburn)%fr_burn * (soil1(j)%hact(1) + soil1(j)%hsta(1))
-          soil1(j)%hact(1) = (1. - fire_db(iburn)%fr_burn) * soil1(j)%hact(1)
-          soil1(j)%hsta(1) = (1. - fire_db(iburn)%fr_burn) * soil1(j)%hsta(1)
-          !! add plant p burn to stable humus pool for constant carbon
-          soil1(j)%hsta(1)%p = soil1(j)%hsta(1)%p + pl_burn%p
-        else
+        if (bsn_cc%cswat == 2) then
           !! dynamic carbon (bsn_cc%cswat == 2)
           pl_burn = fire_db(iburn)%fr_burn * (soil1(j)%hs(1) + soil1(j)%hp(1) + soil1(j)%pl(ipl)%rsd(ipl))
           soil1(j)%hs(1) = (1. - fire_db(iburn)%fr_burn) * soil1(j)%hs(1)

--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -103,13 +103,6 @@
                        fertdb(ifrt)%forgp
         end if
         
-        !! for C-FARM add to manure pool - assume C:N ratio = 10
-        if (bsn_cc%cswat == 1) then
-          soil1(j)%man(l)%c = soil1(j)%man(l)%c + fr_ly * frt_kg * fertdb(ifrt)%forgn * 10.
-          soil1(j)%man(l)%n = soil1(j)%man(l)%n + fr_ly * frt_kg * fertdb(ifrt)%forgn
-          soil1(j)%man(l)%p = soil1(j)%man(l)%p + fr_ly * frt_kg * fertdb(ifrt)%forgp
-        end if
-
         !! for SWAT-C add to slow humus pool and fresh residue pools
         if ((bsn_cc%cswat == 2  .or. bsn_cc%cswat == 3 ) .and. manure_flag) then
           

--- a/src/pl_fert_wet.f90
+++ b/src/pl_fert_wet.f90
@@ -67,14 +67,6 @@
         wet(j)%sedp = wet(j)%sedp + frt_kg * fertdb(ifrt)%forgp
       end if
       
-      !  if (bsn_cc%cswat == 1) then
-      !    soil1(j)%man(l)%c = soil1(j)%man(l)%c + xx * frt_kg *            &
-   !            fertdb(ifrt)%forgn * 10.
-      !    soil1(j)%man(l)%n = soil1(j)%man(l)%n + xx * frt_kg *            &
-   !            fertdb(ifrt)%forgn
-      !    soil1(j)%man(l)%p = soil1(j)%man(l)%p + xx * frt_kg *            &
-   !            fertdb(ifrt)%forgp
-      !  end if
    !
    !     !!By Zhang for C/N cycling 
    !     !!===========================

--- a/src/pl_graze.f90
+++ b/src/pl_graze.f90
@@ -95,20 +95,6 @@
             grazn = manure_kg * (fertdb(it)%forgn + fertdb(it)%fminn)
             grazp = manure_kg * (fertdb(it)%forgp + fertdb(it)%fminp)
           end if
-          if (bsn_cc%cswat == 1) then
-          soil1(j)%mn(l)%no3 = soil1(j)%mn(l)%no3 + manure_kg *       &
-                  (1. - fertdb(it)%fnh3n) * fertdb(it)%fminn
-          soil1(j)%man(l)%n = soil1(j)%man(l)%n + manure_kg *         &
-                       fertdb(it)%forgn
-          soil1(j)%mn(l)%nh4 = soil1(j)%mn(l)%nh4 + manure_kg *       &
-                       fertdb(it)%fnh3n * fertdb(it)%fminn
-          soil1(j)%mp(l)%lab = soil1(j)%mp(l)%lab + manure_kg *       &
-                       fertdb(it)%fminp
-          soil1(j)%man(l)%p = soil1(j)%man(l)%p + manure_kg *         &
-                       fertdb(it)%forgp         
-          soil1(j)%man(l)%c = soil1(j)%man(l)%c + manure_kg *         &
-                       fertdb(it)%forgn * 10.
-          end if
           
           !!By Zhang for C/N cycling
           !!===============================  


### PR DESCRIPTION
This pull request removes all remaining code branches and logic specific to the C-Farm carbon/nitrogen cycling model (where `bsn_cc%cswat == 1`). As a result, only the SWAT-C logic (where `bsn_cc%cswat == 2` or `3`) is now supported for carbon and nitrogen cycling processes throughout the codebase. This simplifies the code and eliminates legacy C-Farm handling.

Key removals and updates:

**Removal of C-Farm (cswat == 1) logic:**

* Removed C-Farm-specific handling for carbon and organic nitrogen in runoff from `hru_control` (`src/hru_control.f90`).
* Deleted C-Farm residue and humus burning logic from `pl_burnop` (`src/pl_burnop.f90`); only dynamic carbon (SWAT-C) logic remains.
* Removed C-Farm manure pool updates in fertilizer application routines `pl_fert` and `pl_fert_wet` (`src/pl_fert.f90`, `src/pl_fert_wet.f90`). [[1]](diffhunk://#diff-9b0e1d4abb3e646ba86be7886b853114a0e7f0df5f3b359e9ec9358c88e5dd79L106-L112) [[2]](diffhunk://#diff-38c7e8425baf4f52d5873a939a30fbae7e0d1d598bdb6974a33cb22c1cccf4daL70-L77)
* Eliminated C-Farm manure and mineral N/P/C handling in grazing operations in `pl_graze` (`src/pl_graze.f90`).
* Removed commented-out or inactive C-Farm tillage mixing logic from `mgt_newtillmix_wet` (`src/mgt_newtillmix_wet.f90`).