### PR TITLE
Revise aquifer water withdrawal logic in wallo_withdraw.f90

### DIFF
--- a/src/wallo_withdraw.f90
+++ b/src/wallo_withdraw.f90
@@ -180,8 +180,7 @@ subroutine wallo_withdraw (iwallo, itrn, isrc)
         case ("aqu") 
           if(bsn_cc%gwflow == 0) then !proceed with original code
           j = wallo(iwallo)%trn(itrn)%src(isrc)%num
-          avail = (wallo(iwallo)%trn(itrn)%src(isrc)%wdraw_lim - aqu_d(j)%dep_wt)  * aqu_dat(j)%spyld
-          avail = avail * 10000. * aqu_prm(j)%area_ha     !m3 = 10,000*ha*m
+          avail = 10. * aqu_prm(j)%area_ha *aqu_d(j)%stor     !m3 = 10.*ha*m
           if (trn_m3 < avail) then
             !! only have flow, no3, and minp(solp) for aquifer
             wal_omd(iwallo)%trn(itrn)%src(isrc)%hd%flo = trn_m3


### PR DESCRIPTION
This pull request makes a targeted change to the calculation of available water withdrawal from an aquifer in the `wallo_withdraw` subroutine. The update simplifies and corrects the formula used to compute `avail`, ensuring it is based directly on aquifer storage and area rather than a more complex calculation involving withdrawal limits and depletion weights.

**Aquifer withdrawal calculation update:**

* In the `"aqu"` case of `wallo_withdraw`, the formula for `avail` is changed to use `10. * aqu_prm(j)%area_ha * aqu_d(j)%stor`, making the calculation rely directly on aquifer storage and area for determining available water.