### PR TITLE
CSV output file fixes

### DIFF
--- a/src/aqu_cs_output.f90
+++ b/src/aqu_cs_output.f90
@@ -48,7 +48,7 @@
                          (acsb_d(iaq)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                          (acsb_d(iaq)%cs(ics)%srbd,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6061,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+          write (6061,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                                                            (acsb_d(iaq)%cs(ics)%csgw,ics=1,cs_db%num_cs), &
                                        (acsb_d(iaq)%cs(ics)%rchrg,ics=1,cs_db%num_cs), &
                                        (acsb_d(iaq)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -97,7 +97,7 @@
                            (acsb_m(iaq)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                            (acsb_m(iaq)%cs(ics)%srbd,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6063,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+            write (6063,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                          (acsb_m(iaq)%cs(ics)%csgw,ics=1,cs_db%num_cs), &
                                          (acsb_m(iaq)%cs(ics)%rchrg,ics=1,cs_db%num_cs), &
                                          (acsb_m(iaq)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -159,7 +159,7 @@
                            (acsb_y(iaq)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                            (acsb_y(iaq)%cs(ics)%srbd,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6065,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+            write (6065,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                          (acsb_y(iaq)%cs(ics)%csgw,ics=1,cs_db%num_cs), &
                                          (acsb_y(iaq)%cs(ics)%rchrg,ics=1,cs_db%num_cs), &
                                          (acsb_y(iaq)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -214,7 +214,7 @@
                         (acsb_a(iaq)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                         (acsb_a(iaq)%cs(ics)%srbd,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6067,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+          write (6067,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                         (acsb_a(iaq)%cs(ics)%csgw,ics=1,cs_db%num_cs), &
                                         (acsb_a(iaq)%cs(ics)%rchrg,ics=1,cs_db%num_cs), &
                                         (acsb_a(iaq)%cs(ics)%seep,ics=1,cs_db%num_cs), &

--- a/src/aqu_pesticide_output.f90
+++ b/src/aqu_pesticide_output.f90
@@ -34,7 +34,7 @@
              write (3008,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest),&
                aqupst_d(j)%pest(ipest)   !! pesticide balance
              if (pco%csvout == "y") then
-               write (3012,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (3012,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                     cs_db%pests(ipest), aqupst_d(j)%pest(ipest)
              end if
           end if
@@ -52,7 +52,7 @@
              write (3009,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                aqupst_m(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (3013,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (3013,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    cs_db%pests(ipest), aqupst_m(j)%pest(ipest)
                end if
            end if
@@ -74,7 +74,7 @@
              write (3010,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                aqupst_y(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (3014,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (3014,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    cs_db%pests(ipest), aqupst_y(j)%pest(ipest)
                end if
            end if
@@ -92,7 +92,7 @@
            write (3011,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
              aqupst_a(j)%pest(ipest)
            if (pco%csvout == "y") then
-             write (3015,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+             write (3015,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                cs_db%pests(ipest), aqupst_a(j)%pest(ipest)
            end if
            

--- a/src/aqu_salt_output.f90
+++ b/src/aqu_salt_output.f90
@@ -43,7 +43,7 @@
                          (asaltb_d(iaq)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                           asaltb_d(iaq)%salt(1)%diss
         if (pco%csvout == "y") then
-          write (5061,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+          write (5061,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                                                             (asaltb_d(iaq)%salt(isalt)%saltgw,isalt=1,cs_db%num_salts), &
                                         (asaltb_d(iaq)%salt(isalt)%rchrg,isalt=1,cs_db%num_salts), &
                                         (asaltb_d(iaq)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -85,7 +85,7 @@
                            (asaltb_m(iaq)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             asaltb_m(iaq)%salt(1)%diss
           if (pco%csvout == "y") then
-            write (5063,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+            write (5063,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                           (asaltb_m(iaq)%salt(isalt)%saltgw,isalt=1,cs_db%num_salts), &
                                           (asaltb_m(iaq)%salt(isalt)%rchrg,isalt=1,cs_db%num_salts), &
                                           (asaltb_m(iaq)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -138,7 +138,7 @@
                            (asaltb_y(iaq)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             asaltb_y(iaq)%salt(1)%diss
           if (pco%csvout == "y") then
-            write (5065,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+            write (5065,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                           (asaltb_y(iaq)%salt(isalt)%saltgw,isalt=1,cs_db%num_salts), &
                                           (asaltb_y(iaq)%salt(isalt)%rchrg,isalt=1,cs_db%num_salts), &
                                           (asaltb_y(iaq)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -184,7 +184,7 @@
                          (asaltb_a(iaq)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                           asaltb_a(iaq)%salt(1)%diss
         if (pco%csvout == "y") then
-          write (5067,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
+          write (5067,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, & 
                                         (asaltb_a(iaq)%salt(isalt)%saltgw,isalt=1,cs_db%num_salts), &
                                         (asaltb_a(iaq)%salt(isalt)%rchrg,isalt=1,cs_db%num_salts), &
                                         (asaltb_a(iaq)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &

--- a/src/aquifer_output.f90
+++ b/src/aquifer_output.f90
@@ -21,7 +21,7 @@
           if (pco%aqu%d == "y") then
             write (2520,100) time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_d(iaq)
             if (pco%csvout == "y") then
-              write (2524,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_d(iaq)
+              write (2524,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_d(iaq)
             end if
           end if
         end if
@@ -36,7 +36,7 @@
           if (pco%aqu%m == "y") then
             write (2521,100)  time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_m(iaq)
             if (pco%csvout == "y") then
-              write (2525,'(*(G0.3,:","))')  time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_m(iaq)
+              write (2525,'(*(G0.6,:","))')  time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_m(iaq)
             endif
           end if
           aqu_m(iaq) = aquz
@@ -51,7 +51,7 @@
           if (pco%aqu%y == "y") then
             write (2522,102) time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_y(iaq)
             if (pco%csvout == "y") then
-              write (2526,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_y(iaq) 
+              write (2526,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_y(iaq) 
             end if
           end if
           !! zero yearly variables        
@@ -63,7 +63,7 @@
         aqu_a(iaq) = aqu_a(iaq) / time%yrs_prt
         write (2523,102) time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_a(iaq)
         if (pco%csvout == "y") then 
-          write (2527,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_a(iaq)  
+          write (2527,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iaq, ob(iob)%gis_id, ob(iob)%name, aqu_a(iaq)  
         end if 
       end if
       

--- a/src/basin_aqu_pest_output.f90
+++ b/src/basin_aqu_pest_output.f90
@@ -41,7 +41,7 @@
              write (3000,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, cs_db%pests(ipest), &
                baqupst_d%pest(ipest)   !! pesticide balance
              if (pco%csvout == "y") then
-               write (3004,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
+               write (3004,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                  cs_db%pests(ipest), baqupst_d%pest(ipest)
              end if
           end if
@@ -61,7 +61,7 @@
              write (3001,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), baqupst_m%pest(ipest)
                if (pco%csvout == "y") then
-                 write (3005,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (3005,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), baqupst_m%pest(ipest)
                end if
            end if
@@ -83,7 +83,7 @@
              write (3002,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), baqupst_y%pest(ipest)
                if (pco%csvout == "y") then
-                 write (3006,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (3006,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), baqupst_y%pest(ipest)
                end if
            end if
@@ -101,7 +101,7 @@
            write (3003,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
              cs_db%pests(ipest), baqupst_a%pest(ipest)
            if (pco%csvout == "y") then
-             write (3007,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+             write (3007,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                ob(iob)%name, cs_db%pests(ipest), baqupst_a%pest(ipest)
            end if
            baqupst_a%pest(ipest) = aqu_pestbz

--- a/src/basin_aquifer_output.f90
+++ b/src/basin_aquifer_output.f90
@@ -28,7 +28,7 @@
           if (pco%aqu_bsn%d == "y") then
             write (2090,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_d
             if (pco%csvout == "y") then
-              write (2094,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_d
+              write (2094,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_d
             end if
           end if
         end if
@@ -43,7 +43,7 @@
           if (pco%aqu_bsn%m == "y") then
             write (2091,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_m
             if (pco%csvout == "y") then
-              write (2095,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_m
+              write (2095,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_m
             endif
           end if
           baqu_m = aquz
@@ -58,7 +58,7 @@
           if (pco%aqu_bsn%y == "y") then
             write (2092,102) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_y
             if (pco%csvout == "y") then
-              write (2096,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_y 
+              write (2096,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_y 
             end if
           end if
           !! zero yearly variables        
@@ -70,7 +70,7 @@
         baqu_a = baqu_a / time%yrs_prt
         write (2093,102) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_a
         if (pco%csvout == "y") then 
-          write (2097,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_a 
+          write (2097,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, baqu_a 
         end if 
       end if
       

--- a/src/basin_ch_pest_output.f90
+++ b/src/basin_ch_pest_output.f90
@@ -38,7 +38,7 @@
              write (2832,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), bchpst_d%pest(ipest)   !! pesticide balance
              if (pco%csvout == "y") then
-               write (2836,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+               write (2836,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                  ob(iob)%name, cs_db%pests(ipest), bchpst_d%pest(ipest)
              end if
           end if
@@ -57,7 +57,7 @@
              write (2833,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), bchpst_m%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2837,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (2837,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), bchpst_m%pest(ipest)
                end if
            end if
@@ -76,7 +76,7 @@
              write (2834,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), bchpst_y%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2838,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (2838,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), bchpst_y%pest(ipest)
                end if
            end if
@@ -90,7 +90,7 @@
            write (2835,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
              cs_db%pests(ipest), bchpst_a%pest(ipest)
            if (pco%csvout == "y") then
-             write (2839,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+             write (2839,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                ob(iob)%name, cs_db%pests(ipest), bchpst_a%pest(ipest)
            end if
            bchpst_a%pest(ipest) = ch_pestbz

--- a/src/basin_chanbud_output.f90
+++ b/src/basin_chanbud_output.f90
@@ -22,7 +22,7 @@
         if (pco%sd_chan_bsn%d == "y") then
           write (2128,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_d
           if (pco%csvout == "y") then
-            write (2132,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_d
+            write (2132,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_d
           end if 
         end if 
       end if
@@ -36,7 +36,7 @@
         if (pco%sd_chan_bsn%m == "y") then
           write (2129,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_m
           if (pco%csvout == "y") then
-            write (2133,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_m
+            write (2133,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_m
           end if
         end if
         bch_sed_bud_m = ch_sed_budz
@@ -51,7 +51,7 @@
         if (pco%sd_chan_bsn%y == "y") then 
           write (2130,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_y
           if (pco%csvout == "y") then
-            write (2134,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_y
+            write (2134,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_y
           end if
         end if
         bch_sed_bud_y = ch_sed_budz
@@ -64,7 +64,7 @@
         
         write (2131,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_a
         if (pco%csvout == "y") then
-          write (2135,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_a
+          write (2135,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_sed_bud_a
         end if
       end if
 

--- a/src/basin_chanmorph_output.f90
+++ b/src/basin_chanmorph_output.f90
@@ -24,7 +24,7 @@
         if (pco%sd_chan_bsn%d == "y") then
           write (2120,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_d
           if (pco%csvout == "y") then
-            write (2124,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_d
+            write (2124,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_d
           end if 
         end if 
       end if
@@ -38,7 +38,7 @@
         if (pco%sd_chan_bsn%m == "y") then
           write (2121,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_m
           if (pco%csvout == "y") then
-            write (2125,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_m
+            write (2125,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_m
           end if
         end if
         bchsd_m = chsdz
@@ -53,7 +53,7 @@
         if (pco%sd_chan_bsn%y == "y") then 
           write (2122,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_y
           if (pco%csvout == "y") then
-            write (2126,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_y
+            write (2126,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_y
           end if
         end if
         
@@ -67,7 +67,7 @@
         
         write (2123,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_a
         if (pco%csvout == "y") then
-          write (2127,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_a
+          write (2127,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bchsd_a
         end if
       end if
 

--- a/src/basin_channel_output.f90
+++ b/src/basin_channel_output.f90
@@ -24,7 +24,7 @@
         if (pco%chan_bsn%d == "y") then
           write (2110,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_d
           if (pco%csvout == "y") then
-            write (2114,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_d
+            write (2114,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_d
           end if 
         end if 
       end if
@@ -35,7 +35,7 @@
         if (pco%chan_bsn%m == "y") then
           write (2111,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_m
           if (pco%csvout == "y") then
-            write (2115,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_m
+            write (2115,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_m
           end if
         end if
         bch_m = chz
@@ -47,7 +47,7 @@
         if (pco%chan_bsn%y == "y") then 
           write (2112,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_y
           if (pco%csvout == "y") then
-            write (2116,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_y
+            write (2116,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_y
           end if
         end if
         
@@ -59,7 +59,7 @@
         bch_a = bch_a / time%yrs_prt
         write (2113,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_a
         if (pco%csvout == "y") then
-          write (2117,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_a
+          write (2117,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_a
         end if
       end if
 

--- a/src/basin_ls_pest_output.f90
+++ b/src/basin_ls_pest_output.f90
@@ -41,7 +41,7 @@
             write (2864,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), bpestb_d%pest(ipest)   !! pesticide balance
             if (pco%csvout == "y") then
-              write (2868,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+              write (2868,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                  ob(iob)%name, cs_db%pests(ipest), bpestb_d%pest(ipest)
             end if
           end if
@@ -60,7 +60,7 @@
              write (2865,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), bpestb_m%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2869,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (2869,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), bpestb_m%pest(ipest)
                end if
            end if
@@ -79,7 +79,7 @@
              write (2866,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), bpestb_y%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2870,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (2870,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), bpestb_y%pest(ipest)
                end if
            end if
@@ -93,7 +93,7 @@
            write (2867,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
              cs_db%pests(ipest), bpestb_a%pest(ipest)
            if (pco%csvout == "y") then
-             write (2871,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+             write (2871,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                ob(iob)%name, cs_db%pests(ipest), bpestb_a%pest(ipest)
            end if
            bpestb_a%pest(ipest) = pestbz

--- a/src/basin_output.f90
+++ b/src/basin_output.f90
@@ -71,7 +71,7 @@
             bwb_d%snopack = (bwb_d%sno_init + bwb_d%sno_final) / 2.
             write (2050,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_d  !! waterbal
             if (pco%csvout == "y") then 
-              write (2054,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_d  !! waterbal
+              write (2054,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_d  !! waterbal
             end if
             bwb_d%sw_init = bwb_d%sw_final
             bwb_d%sno_init = bwb_d%sno_final
@@ -79,19 +79,19 @@
           if (pco%nb_bsn%d == "y") then 
             write (2060,104) time%day, time%mo, time%day_mo, time%yrc, "        1", "       1", bsn%name, bnb_d  !! nutrient bal
             if (pco%csvout == "y") then 
-              write (2064,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_d  !! nutrient bal
+              write (2064,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_d  !! nutrient bal
               end if
           end if
           if (pco%ls_bsn%d == "y") then
             write (2070,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_d  !! losses
             if (pco%csvout == "y") then 
-              write (2074,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_d  !! losses
+              write (2074,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_d  !! losses
             end if 
           end if
           if (pco%pw_bsn%d == "y") then
             write (2080,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_d  !! plant weather
             if (pco%csvout == "y") then 
-              write (2084,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_d  !! plant weather
+              write (2084,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_d  !! plant weather
             end if
           end if
         end if
@@ -111,7 +111,7 @@
             bwb_m%sno_final = bwb_d%sno_final
             write (2051,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_m
             if (pco%csvout == "y") then 
-              write (2055,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_m
+              write (2055,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_m
             end if
             bwb_m%sw_init = bwb_m%sw_final
             bwb_m%sno_init = bwb_m%sno_final
@@ -119,13 +119,13 @@
           if (pco%nb_bsn%m == "y") then 
             write (2061,104) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_m 
             if (pco%csvout == "y") then 
-              write (2065,104) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_m
+              write (2065,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_m
               end if 
           end if
           if (pco%ls_bsn%m == "y") then  
             write (2071,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_m
             if (pco%csvout == "y") then 
-              write (2075,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_m
+              write (2075,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_m
             end if 
           end if
           if (pco%pw_bsn%m == "y") then
@@ -133,7 +133,7 @@
             !bpw_m%nplnt = bpw_d%pplnt
             write (2081,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_m
             if (pco%csvout == "y") then 
-              write (2085,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_m
+              write (2085,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_m
               end if 
           end if
   
@@ -163,7 +163,7 @@
              bwb_y%sno_final = bwb_d%sno_final
              write (2052,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_y
              if (pco%csvout == "y") then 
-                write (2056,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_y
+                write (2056,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_y
              end if
              bwb_y%sw_init = bwb_y%sw_final
              bwb_y%sno_init = bwb_y%sno_final
@@ -171,13 +171,13 @@
            if (pco%nb_bsn%y == "y") then
              write (2062,104) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_y
              if (pco%csvout == "y") then 
-               write (2066,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_y
+               write (2066,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_y
              end if
            end if
            if (pco%ls_bsn%y == "y") then
              write (2072,100)time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_y
              if (pco%csvout == "y") then 
-                write (2076,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_y
+                write (2076,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_y
              end if 
            end if
            if (pco%pw_bsn%y == "y") then
@@ -185,7 +185,7 @@
              !bpw_y%nplnt = bpw_d%pplnt
              write (2082,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_y
              if (pco%csvout == "y") then 
-               write (2086,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_y
+               write (2086,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_y
              end if 
            end if
  
@@ -214,7 +214,7 @@
         if (pco%wb_bsn%a == "y") then
         write (2053,103) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_a, cal_sim, cal_adj
         if (pco%csvout == "y") then 
-          write (2057,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_a,    &
+          write (2057,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bwb_a,    &
                     cal_sim, cal_adj
         end if
         end if
@@ -226,7 +226,7 @@
         if (pco%nb_bsn%a == "y") then
         write (2063,104) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_a
         if (pco%csvout == "y") then 
-          write (2067,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_a
+          write (2067,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bnb_a
         end if
         end if
       end if
@@ -235,7 +235,7 @@
         if (pco%ls_bsn%a == "y") then
         write (2073,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_a
         if (pco%csvout == "y") then 
-          write (2077,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_a
+          write (2077,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bls_a
         end if
         end if
       end if
@@ -245,7 +245,7 @@
         if (pco%pw_bsn%a == "y") then
         write (2083,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", bsn%name, bpw_a
         if (pco%csvout == "y") then 
-          write (2087,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "        1", bsn%name, bpw_a
+          write (2087,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "        1", bsn%name, bpw_a
         end if
         end if
       end if

--- a/src/basin_recall_output.f90
+++ b/src/basin_recall_output.f90
@@ -22,7 +22,7 @@
           if (pco%recall_bsn%d == "y") then
             write (4500,*) time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_d
             if (pco%csvout == "y") then
-              write (4504,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_d
+              write (4504,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_d
             end if
           end if
         end if
@@ -33,7 +33,7 @@
           if (pco%recall_bsn%m == "y") then
             write (4501,*) time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_m
             if (pco%csvout == "y") then
-              write (4505,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_m
+              write (4505,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_m
             endif
           end if
           brec_m = hz
@@ -45,7 +45,7 @@
           if (pco%recall_bsn%y == "y") then
             write (4502,*) time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_y
             if (pco%csvout == "y") then
-              write (4506,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_y 
+              write (4506,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_y 
             end if
           end if
           !! zero yearly variables        
@@ -58,7 +58,7 @@
         brec_a = brec_a / time%yrs_prt
         write (4503,*) time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_a
         if (pco%csvout == "y") then 
-          write (4507,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_a 
+          write (4507,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, bsn%name, brec_a 
         end if 
       end if
       

--- a/src/basin_res_pest_output.f90
+++ b/src/basin_res_pest_output.f90
@@ -38,7 +38,7 @@
              write (2848,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                ob(iob)%name, cs_db%pests(ipest), brespst_d%pest(ipest)   !! pesticide balance
              if (pco%csvout == "y") then
-               write (2852,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+               write (2852,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                  ob(iob)%name, cs_db%pests(ipest), brespst_d%pest(ipest)
              end if
           end if
@@ -57,7 +57,7 @@
              write (2849,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), brespst_m%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2853,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (2853,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), brespst_m%pest(ipest)
                end if
            end if
@@ -76,7 +76,7 @@
              write (2850,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
                cs_db%pests(ipest), brespst_y%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2854,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+                 write (2854,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                    ob(iob)%name, cs_db%pests(ipest), brespst_y%pest(ipest)
                end if
            end if
@@ -90,7 +90,7 @@
            write (2851,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", ob(iob)%name, &
              cs_db%pests(ipest), brespst_a%pest(ipest)
            if (pco%csvout == "y") then
-             write (2855,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
+             write (2855,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "       1", &
                ob(iob)%name, cs_db%pests(ipest), brespst_a%pest(ipest)
            end if
            brespst_a%pest(ipest) = res_pestbz

--- a/src/basin_reservoir_output.f90
+++ b/src/basin_reservoir_output.f90
@@ -39,7 +39,7 @@
             write (2100,100) time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, bres_wat_d, &
               bres, bres_in_d, bres_out_d
             if (pco%csvout == "y") then
-              write (2104,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, &
+              write (2104,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, &
                 bres_wat_d, bres, bres_in_d, bres_out_d
             end if
           end if
@@ -56,7 +56,7 @@
            write (2101,100) time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name,  bres_wat_m, bres, &
              bres_in_m, bres_out_m 
             if (pco%csvout == "y") then
-              write (2105,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name,  &
+              write (2105,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name,  &
                 bres_wat_m, bres, bres_in_m, bres_out_m
             endif
           end if
@@ -75,7 +75,7 @@
             write (2102,100) time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name,  bres_wat_y, &
               bres, bres_in_y, bres_out_y
             if (pco%csvout == "y") then
-              write (2106,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, &
+              write (2106,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, &
                 bres_wat_y, bres, bres_in_y, bres_out_y 
             end if
           end if
@@ -93,7 +93,7 @@
         write (2103,100) time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, bres_wat_a, bres, &
           bres_in_a, bres_out_a
         if (pco%csvout == "y") then 
-          write (2107,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, &
+          write (2107,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ires, "     1", bsn%name, &
             bres_wat_a, bres, bres_in_a, bres_out_a
         end if 
       end if

--- a/src/basin_sdchannel_output.f90
+++ b/src/basin_sdchannel_output.f90
@@ -34,7 +34,7 @@
           write (4900,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_wat_d, &
           bch_stor_d, bch_in_d, bch_out_d
           if (pco%csvout == "y") then
-            write (4904,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, &
+            write (4904,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, &
             bch_wat_d, bch_stor_d, bch_in_d, bch_out_d
           end if 
         end if 
@@ -52,7 +52,7 @@
           write (4901,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_wat_m, &
             bch_stor_d, bch_in_m, bch_out_m
           if (pco%csvout == "y") then
-            write (4905,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, &
+            write (4905,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, &
               bch_wat_m, bch_stor_d, bch_in_m, bch_out_m
           end if
         end if
@@ -73,7 +73,7 @@
           write (4902,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_wat_y, &
             bch_stor_d, bch_in_y, bch_out_y
           if (pco%csvout == "y") then
-            write (4906,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name,&
+            write (4906,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name,&
               bch_wat_y, bch_stor_d, bch_in_y, bch_out_y
           end if
         end if
@@ -91,7 +91,7 @@
         write (4903,100) time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, bch_wat_a, &
           bch_stor_d, bch_in_a, bch_out_a
         if (pco%csvout == "y") then
-          write (4907,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, &
+          write (4907,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, "       1", "     1", bsn%name, &
             bch_wat_a, bch_stor_d, bch_in_a, bch_out_a
         end if
       end if

--- a/src/ch_cs_output.f90
+++ b/src/ch_cs_output.f90
@@ -50,7 +50,7 @@
                          (chcs_d(iru)%cs(ics)%water,ics=1,cs_db%num_cs), &
                          (chcs_d(iru)%cs(ics)%conc,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6031,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (6031,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                         (chcs_d(iru)%cs(ics)%tot_in,ics=1,cs_db%num_cs), &
                                         (chcs_d(iru)%cs(ics)%gw_in,ics=1,cs_db%num_cs), &
                                         (chcs_d(iru)%cs(ics)%tot_out,ics=1,cs_db%num_cs), &
@@ -92,7 +92,7 @@
                            (chcs_m(iru)%cs(ics)%water,ics=1,cs_db%num_cs), &
                            (chcs_m(iru)%cs(ics)%conc,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6033,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (6033,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                           (chcs_m(iru)%cs(ics)%tot_in,ics=1,cs_db%num_cs), &
                                           (chcs_m(iru)%cs(ics)%gw_in,ics=1,cs_db%num_cs), &
                                           (chcs_m(iru)%cs(ics)%tot_out,ics=1,cs_db%num_cs), &
@@ -145,7 +145,7 @@
                            (chcs_y(iru)%cs(ics)%water,ics=1,cs_db%num_cs), &
                            (chcs_y(iru)%cs(ics)%conc,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6035,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (6035,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                           (chcs_y(iru)%cs(ics)%tot_in,ics=1,cs_db%num_cs), &
                                           (chcs_y(iru)%cs(ics)%gw_in,ics=1,cs_db%num_cs), &
                                           (chcs_y(iru)%cs(ics)%tot_out,ics=1,cs_db%num_cs), &
@@ -192,7 +192,7 @@
                          (chcs_a(iru)%cs(ics)%water,ics=1,cs_db%num_cs), &
                          (chcs_a(iru)%cs(ics)%conc,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6037,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (6037,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                         (chcs_a(iru)%cs(ics)%tot_in,ics=1,cs_db%num_cs), &
                                         (chcs_a(iru)%cs(ics)%gw_in,ics=1,cs_db%num_cs), &
                                         (chcs_a(iru)%cs(ics)%tot_out,ics=1,cs_db%num_cs), &

--- a/src/ch_salt_output.f90
+++ b/src/ch_salt_output.f90
@@ -49,7 +49,7 @@
                          (chsalt_d(iru)%salt(isalt)%water,isalt=1,cs_db%num_salts), &
                          (chsalt_d(iru)%salt(isalt)%conc,isalt=1,cs_db%num_salts)
         if (pco%csvout == "y") then
-          write (5031,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (5031,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                         (chsalt_d(iru)%salt(isalt)%tot_in,isalt=1,cs_db%num_salts), &
                                         (chsalt_d(iru)%salt(isalt)%gw_in,isalt=1,cs_db%num_salts), &
                                         (chsalt_d(iru)%salt(isalt)%tot_out,isalt=1,cs_db%num_salts), &
@@ -91,7 +91,7 @@
                            (chsalt_m(iru)%salt(isalt)%water,isalt=1,cs_db%num_salts), &
                            (chsalt_m(iru)%salt(isalt)%conc,isalt=1,cs_db%num_salts)
           if (pco%csvout == "y") then
-            write (5033,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (5033,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                           (chsalt_m(iru)%salt(isalt)%tot_in,isalt=1,cs_db%num_salts), &
                                           (chsalt_m(iru)%salt(isalt)%gw_in,isalt=1,cs_db%num_salts), &
                                           (chsalt_m(iru)%salt(isalt)%tot_out,isalt=1,cs_db%num_salts), &
@@ -144,7 +144,7 @@
                            (chsalt_y(iru)%salt(isalt)%water,isalt=1,cs_db%num_salts), &
                            (chsalt_y(iru)%salt(isalt)%conc,isalt=1,cs_db%num_salts)
           if (pco%csvout == "y") then
-            write (5035,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (5035,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                           (chsalt_y(iru)%salt(isalt)%tot_in,isalt=1,cs_db%num_salts), &
                                           (chsalt_y(iru)%salt(isalt)%gw_in,isalt=1,cs_db%num_salts), &
                                           (chsalt_y(iru)%salt(isalt)%tot_out,isalt=1,cs_db%num_salts), &
@@ -191,7 +191,7 @@
                          (chsalt_a(iru)%salt(isalt)%water,isalt=1,cs_db%num_salts), &
                          (chsalt_a(iru)%salt(isalt)%conc,isalt=1,cs_db%num_salts)
         if (pco%csvout == "y") then
-          write (5037,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (5037,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                         (chsalt_a(iru)%salt(isalt)%tot_in,isalt=1,cs_db%num_salts), &
                                         (chsalt_a(iru)%salt(isalt)%gw_in,isalt=1,cs_db%num_salts), &
                                         (chsalt_a(iru)%salt(isalt)%tot_out,isalt=1,cs_db%num_salts), &

--- a/src/cha_pesticide_output.f90
+++ b/src/cha_pesticide_output.f90
@@ -36,7 +36,7 @@
              write (2808,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                chpst_d(j)%pest(ipest)   !! pesticide balance
              if (pco%csvout == "y") then
-               write (2812,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2812,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                  cs_db%pests(ipest), chpst_d(j)%pest(ipest)
              end if
           end if
@@ -55,7 +55,7 @@
              write (2809,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                chpst_m(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2813,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2813,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    cs_db%pests(ipest), chpst_m(j)%pest(ipest)
                end if
            end if
@@ -74,7 +74,7 @@
              write (2810,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                chpst_y(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2814,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2814,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    cs_db%pests(ipest), chpst_y(j)%pest(ipest)
                end if
            end if
@@ -88,7 +88,7 @@
            write (2811,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
              chpst_a(j)%pest(ipest)
            if (pco%csvout == "y") then
-             write (2815,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+             write (2815,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                cs_db%pests(ipest), chpst_a(j)%pest(ipest)
            end if
            chpst_a(j)%pest(ipest) = ch_pestbz

--- a/src/channel_output.f90
+++ b/src/channel_output.f90
@@ -28,7 +28,7 @@
         if (pco%chan%d == "y") then
           write (2480,100) time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_d(jrch)
           if (pco%csvout == "y") then
-            write (2484,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_d(jrch)
+            write (2484,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_d(jrch)
           end if 
         end if 
       end if
@@ -39,7 +39,7 @@
         if (pco%chan%m == "y") then
           write (2481,100) time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_m(jrch)
           if (pco%csvout == "y") then
-            write (2485,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_m(jrch)
+            write (2485,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_m(jrch)
           end if
         end if
         ch_m(jrch) = chz
@@ -51,7 +51,7 @@
         if (pco%chan%y == "y") then 
           write (2482,100) time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_y(jrch)
           if (pco%csvout == "y") then
-            write (2486,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_y(jrch)
+            write (2486,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_y(jrch)
           end if
         end if
         
@@ -63,7 +63,7 @@
         ch_a(jrch) = ch_a(jrch) / time%yrs_prt
         write (2483,100) time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_a(jrch)
         if (pco%csvout == "y") then
-          write (2487,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_a(jrch)
+          write (2487,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, jrch, ob(iob)%gis_id, ob(iob)%name, ch_a(jrch)
         end if
       end if
 

--- a/src/hcsin_output.f90
+++ b/src/hcsin_output.f90
@@ -23,7 +23,7 @@
               ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),          &
              ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2724,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2724,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -34,7 +34,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),          &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2728,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2728,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -45,7 +45,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),          &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2732,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2732,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -56,7 +56,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2736,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2736,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_d(iin)%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts
@@ -74,7 +74,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2725,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2725,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -85,7 +85,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                  ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2729,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2729,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -96,7 +96,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2733,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2733,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -107,7 +107,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2737,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2737,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_m(iin)%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts
@@ -125,7 +125,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2726,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2726,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                    ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                       &
                    ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -136,7 +136,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2730,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
+                write (2730,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                       &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -147,7 +147,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2734,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2734,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -158,7 +158,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2738,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2738,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_y(iin)%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts
@@ -176,7 +176,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2727,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2727,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                        &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -187,7 +187,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2731,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2731,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                   ob(iob)%num,ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -198,7 +198,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                  ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2735,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id,ob(iob)%typ,   &
+                write (2735,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id,ob(iob)%typ,   &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                       &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -209,7 +209,7 @@
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),         &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2739,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
+                write (2739,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
                   ob(iob)%num, ob(iob)%obtyp_in(iin), ob(iob)%obtypno_in(iin), ob(iob)%htyp_in(iin),                       &
                   ob(iob)%frac_in(iin), (obcs(iob)%hcsin_a(iin)%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts

--- a/src/hcsout_output.f90
+++ b/src/hcsout_output.f90
@@ -23,7 +23,7 @@
                ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),  &
                ob(iob)%frac_out(iiout), (hcs1%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2756,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  & 
+                write (2756,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  & 
                   ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),              &
                   ob(iob)%frac_out(iiout), (hcs1%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -34,7 +34,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout), &
                  ob(iob)%frac_out(iiout), (hcs1%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2760,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  & 
+                write (2760,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  & 
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),               &
                  ob(iob)%frac_out(iiout), (hcs1%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -45,7 +45,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout), &
                  ob(iob)%frac_out(iiout), (hcs1%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2764,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
+                write (2764,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),               &
                  ob(iob)%frac_out(iiout), (hcs1%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -56,7 +56,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),  &
                  ob(iob)%frac_out(iiout), (hcs1%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2768,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
+                write (2768,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),               &
                  ob(iob)%frac_out(iiout), (hcs1%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts
@@ -74,7 +74,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),   &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2757,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
+                write (2757,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,  &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),               &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -85,7 +85,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),   &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2761,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2761,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -96,7 +96,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),     &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2765,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2765,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -107,7 +107,7 @@
                 ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),   &
                 ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2769,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2769,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_m(iiout)%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts
@@ -125,7 +125,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),   &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2752,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2752,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -136,7 +136,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),    &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2762,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2762,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -147,7 +147,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),    &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2766,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2766,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -158,7 +158,7 @@
                 ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),   &
                 ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2770,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2770,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_y(iiout)%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts
@@ -176,7 +176,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),   &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%pest(ipest), ipest = 1, cs_db%num_pests)          
               if (pco%csvout == "y") then
-                write (2759,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,    &
+                write (2759,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,    &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                 &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%pest(ipest), ipest = 1, cs_db%num_pests)
               end if                             !! cvs pests
@@ -187,7 +187,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),  &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%path(ipath), ipath = 1, cs_db%num_paths)          
               if (pco%csvout == "y") then
-                write (2763,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2763,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%path(ipath), ipath = 1, cs_db%num_paths)
               end if                            !! cvs paths
@@ -198,7 +198,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),    &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%hmet(imetal), imetal = 1, cs_db%num_metals)          
               if (pco%csvout == "y") then
-                write (2767,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2767,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%hmet(imetal), imetal = 1, cs_db%num_metals)
               end if                            !! cvs metals
@@ -209,7 +209,7 @@
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),  &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%salt(isalt), isalt = 1, cs_db%num_salts)          
               if (pco%csvout == "y") then
-                write (2771,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
+                write (2771,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iob, ob(iob)%gis_id, ob(iob)%typ,   &
                  ob(iob)%num, ob(iob)%obtyp_out(iiout), ob(iob)%obtypno_out(iiout), ob(iob)%htyp_out(iiout),                &
                  ob(iob)%frac_out(iiout), (obcs(iob)%hcsout_a(iiout)%salt(isalt), isalt = 1, cs_db%num_salts)
               end if                            !! cvs salts

--- a/src/header_aquifer.f90
+++ b/src/header_aquifer.f90
@@ -18,8 +18,8 @@
          if (pco%csvout == "y") then
             call open_output_file(2524, "aquifer_day.csv", 1500)
             write (2524,*) bsn%name, prog
-            write (2524,'(*(G0.3,:,","))') aqu_hdr   !! aquifer csv
-            write (2524,'(*(G0.3,:,","))') aqu_hdr_units
+            write (2524,'(*(G0.6,:,","))') aqu_hdr   !! aquifer csv
+            write (2524,'(*(G0.6,:,","))') aqu_hdr_units
             write (9000,*) "AQUIFER                   aquifer_day.csv"
          end if
         endif
@@ -35,8 +35,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2525, "aquifer_mon.csv", 1500)
             write (2525,*) bsn%name, prog
-            write (2525,'(*(G0.3,:,","))') aqu_hdr   !! aquifer csv
-            write (2525,'(*(G0.3,:,","))') aqu_hdr_units
+            write (2525,'(*(G0.6,:,","))') aqu_hdr   !! aquifer csv
+            write (2525,'(*(G0.6,:,","))') aqu_hdr_units
             write (9000,*) "AQUIFER                   aquifer_mon.csv"
           end if
          end if
@@ -52,8 +52,8 @@
          if (pco%csvout == "y") then
             call open_output_file(2526, "aquifer_yr.csv", 1500)
             write (2526,*) bsn%name, prog
-            write (2526,'(*(G0.3,:,","))') aqu_hdr   !! aquifer csv
-            write (2526,'(*(G0.3,:,","))') aqu_hdr_units
+            write (2526,'(*(G0.6,:,","))') aqu_hdr   !! aquifer csv
+            write (2526,'(*(G0.6,:,","))') aqu_hdr_units
             write (9000,*) "AQUIFER                   aquifer_yr.csv"
          end if
         endif
@@ -69,8 +69,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2527, "aquifer_aa.csv", 1500)
             write (2527,*) bsn%name, prog
-            write (2527,'(*(G0.3,:,","))') aqu_hdr   !! aquifer csv
-            write (2527,'(*(G0.3,:,","))') aqu_hdr_units
+            write (2527,'(*(G0.6,:,","))') aqu_hdr   !! aquifer csv
+            write (2527,'(*(G0.6,:,","))') aqu_hdr_units
             write (9000,*) "AQUIFER                   aquifer_aa.csv"
           end if
          end if 

--- a/src/header_channel.f90
+++ b/src/header_channel.f90
@@ -15,7 +15,7 @@
           !write (9000,*) "CHANNEL             channel_subday.txt"
           !if (pco%csvout == "y")  then
           !  open (,file="channel_subday.csv",recl = 1500)
-          !  write (,'(*(G0.3,:,","))') ch_hdr !! channel header csv format
+          !  write (,'(*(G0.6,:,","))') ch_hdr !! channel header csv format
           ! write (9000,*) "CHANNEL             channel_subday.csv"
           !end if
         !endif
@@ -31,8 +31,8 @@
           if (pco%csvout == "y")  then
             call open_output_file(2484, "channel_day.csv", 1500)
             write (2484,*) bsn%name, prog
-            write (2484,'(*(G0.3,:,","))') ch_hdr !! channel header csv format
-            write (2484,'(*(G0.3,:,","))') ch_hdr_units
+            write (2484,'(*(G0.6,:,","))') ch_hdr !! channel header csv format
+            write (2484,'(*(G0.6,:,","))') ch_hdr_units
            write (9000,*) "CHANNEL                   channel_day.csv"
           end if
         endif
@@ -48,8 +48,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2485, "channel_mon.csv", 1500)
             write (2485,*) bsn%name, prog
-            write (2485,'(*(G0.3,:,","))') ch_hdr   !! channel aa header csv format
-            write (2485,'(*(G0.3,:,","))') ch_hdr_units
+            write (2485,'(*(G0.6,:,","))') ch_hdr   !! channel aa header csv format
+            write (2485,'(*(G0.6,:,","))') ch_hdr_units
             write (9000,*) "CHANNEL                   channel_mon.csv"
           end if
           end if
@@ -65,8 +65,8 @@
           if (pco%csvout == "y")  then
             call open_output_file(2486, "channel_yr.csv", 1500)
             write (2486,*) bsn%name, prog
-            write (2486,'(*(G0.3,:,","))') ch_hdr !! channel header csv format
-            write (2486,'(*(G0.3,:,","))') ch_hdr_units
+            write (2486,'(*(G0.6,:,","))') ch_hdr !! channel header csv format
+            write (2486,'(*(G0.6,:,","))') ch_hdr_units
            write (9000,*) "CHANNEL                   channel_yr.csv"
           end if
         endif
@@ -82,8 +82,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2487, "channel_aa.csv", 1500)
             write (2487,*) bsn%name, prog
-            write (2487,'(*(G0.3,:,","))') ch_hdr   !! channel aa header csv format
-            write (2487,'(*(G0.3,:,","))') ch_hdr_units
+            write (2487,'(*(G0.6,:,","))') ch_hdr   !! channel aa header csv format
+            write (2487,'(*(G0.6,:,","))') ch_hdr_units
             write (9000,*) "CHANNEL                   channel_aa.csv"
           end if
           end if

--- a/src/header_const.f90
+++ b/src/header_const.f90
@@ -222,7 +222,7 @@
          call open_output_file(6022, "hru_cs_day.csv", 3000)
          write (6022,*) bsn%name, prog
          write (6022,*) 'conc = mg/L; other = kg/ha'
-         write (6022,'(*(G0.3,:","))') cs_hdr_hru
+         write (6022,'(*(G0.6,:","))') cs_hdr_hru
        endif
      endif
      
@@ -263,7 +263,7 @@
          call open_output_file(6024, "hru_cs_mon.csv", 3000)
          write (6024,*) bsn%name, prog
          write (6024,*) 'conc = mg/L; other = kg/ha'
-         write (6024,'(*(G0.3,:","))') cs_hdr_hru
+         write (6024,'(*(G0.6,:","))') cs_hdr_hru
        endif
      endif
      
@@ -304,7 +304,7 @@
          call open_output_file(6026, "hru_cs_yr.csv", 3000)
          write (6026,*) bsn%name, prog
          write (6026,*) 'conc = mg/L; other = kg/ha'
-         write (6026,'(*(G0.3,:","))') cs_hdr_hru
+         write (6026,'(*(G0.6,:","))') cs_hdr_hru
        endif
      endif
      
@@ -345,7 +345,7 @@
          call open_output_file(6028, "hru_cs_aa.csv", 3000)
          write (6028,*) bsn%name, prog
          write (6028,*) 'conc = mg/L; other = kg/ha'
-         write (6028,'(*(G0.3,:","))') cs_hdr_hru
+         write (6028,'(*(G0.6,:","))') cs_hdr_hru
        endif
      endif
 
@@ -376,7 +376,7 @@
            call open_output_file(6061, "aquifer_cs_day.csv", 2000)
            write (6061,*) bsn%name, prog
            write (6061,*) 'conc = mg/L; other = kg'
-           write (6061,'(*(G0.3,:","))') cs_hdr_aqu
+           write (6061,'(*(G0.6,:","))') cs_hdr_aqu
          endif
        endif
      endif
@@ -408,7 +408,7 @@
            call open_output_file(6063, "aquifer_cs_mon.csv", 2000)
            write (6063,*) bsn%name, prog
            write (6063,*) 'conc = mg/L; other = kg'
-           write (6063,'(*(G0.3,:","))') cs_hdr_aqu
+           write (6063,'(*(G0.6,:","))') cs_hdr_aqu
          endif
        endif
      endif
@@ -440,7 +440,7 @@
            call open_output_file(6065, "aquifer_cs_yr.csv", 2000)
            write (6065,*) bsn%name, prog
            write (6065,*) 'conc = mg/L; other = kg'
-           write (6065,'(*(G0.3,:","))') cs_hdr_aqu
+           write (6065,'(*(G0.6,:","))') cs_hdr_aqu
          endif
        endif
      endif
@@ -472,7 +472,7 @@
            call open_output_file(6067, "aquifer_cs_aa.csv", 2000)
            write (6067,*) bsn%name, prog
            write (6067,*) 'conc = mg/L; other = kg'
-           write (6067,'(*(G0.3,:","))') cs_hdr_aqu
+           write (6067,'(*(G0.6,:","))') cs_hdr_aqu
          endif
        endif
      endif
@@ -501,7 +501,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6031, "channel_cs_day.csv", 2000)
            write (6031,*) bsn%name, prog
-           write (6031,'(*(G0.3,:","))') chcs_hdr
+           write (6031,'(*(G0.6,:","))') chcs_hdr
          endif
        endif
      endif
@@ -530,7 +530,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6033, "channel_cs_mon.csv", 2000)
            write (6033,*) bsn%name, prog
-           write (6033,'(*(G0.3,:","))') chcs_hdr
+           write (6033,'(*(G0.6,:","))') chcs_hdr
          endif
        endif
      endif
@@ -559,7 +559,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6035, "channel_cs_yr.csv", 2000)
            write (6035,*) bsn%name, prog
-           write (6035,'(*(G0.3,:","))') chcs_hdr
+           write (6035,'(*(G0.6,:","))') chcs_hdr
          endif
        endif
      endif
@@ -588,7 +588,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6037, "channel_cs_aa.csv", 2000)
            write (6037,*) bsn%name, prog
-           write (6037,'(*(G0.3,:","))') chcs_hdr
+           write (6037,'(*(G0.6,:","))') chcs_hdr
          endif
        endif
      endif
@@ -621,7 +621,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6041, "reservoir_cs_day.csv", 2000)
            write (6041,*) bsn%name, prog
-           write (6041,'(*(G0.3,:","))') rescs_hdr
+           write (6041,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif
@@ -654,7 +654,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6043, "reservoir_cs_mon.csv", 2000)
            write (6043,*) bsn%name, prog
-           write (6043,'(*(G0.3,:","))') rescs_hdr
+           write (6043,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif
@@ -687,7 +687,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6045, "reservoir_cs_yr.csv", 2000)
            write (6045,*) bsn%name, prog
-           write (6045,'(*(G0.3,:","))') rescs_hdr
+           write (6045,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif
@@ -720,7 +720,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6047, "reservoir_cs_aa.csv", 2000)
            write (6047,*) bsn%name, prog
-           write (6047,'(*(G0.3,:","))') rescs_hdr
+           write (6047,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif 
@@ -758,7 +758,7 @@
            call open_output_file(6071, "rout_unit_cs_day.csv", 2000)
            write (6071,*) bsn%name, prog
            write (6071,*) 'all values in kg'
-           write (6071,'(*(G0.3,:","))') rucsb_hdr
+           write (6071,'(*(G0.6,:","))') rucsb_hdr
          endif
        endif
      endif
@@ -796,7 +796,7 @@
            call open_output_file(6073, "rout_unit_cs_mon.csv", 2000)
            write (6073,*) bsn%name, prog
            write (6073,*) 'all values in kg'
-           write (6073,'(*(G0.3,:","))') rucsb_hdr
+           write (6073,'(*(G0.6,:","))') rucsb_hdr
          endif
        endif
      endif
@@ -834,7 +834,7 @@
            call open_output_file(6075, "rout_unit_cs_yr.csv", 2000)
            write (6075,*) bsn%name, prog
            write (6075,*) 'all values in kg'
-           write (6075,'(*(G0.3,:","))') rucsb_hdr
+           write (6075,'(*(G0.6,:","))') rucsb_hdr
          endif
        endif
      endif
@@ -872,7 +872,7 @@
            call open_output_file(6077, "rout_unit_cs_aa.csv", 2000)
            write (6077,*) bsn%name, prog
            write (6077,*) 'all values in kg'
-           write (6077,'(*(G0.3,:","))') rucsb_hdr
+           write (6077,'(*(G0.6,:","))') rucsb_hdr
          endif
        endif
      endif 
@@ -904,7 +904,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6091, "wetland_cs_day.csv", 2000)
            write (6091,*) bsn%name, prog
-           write (6091,'(*(G0.3,:","))') rescs_hdr
+           write (6091,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif
@@ -936,7 +936,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6093, "wetland_cs_mon.csv", 2000)
            write (6093,*) bsn%name, prog
-           write (6093,'(*(G0.3,:","))') rescs_hdr
+           write (6093,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif
@@ -968,7 +968,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6095, "wetland_cs_yr.csv", 2000)
            write (6095,*) bsn%name, prog
-           write (6095,'(*(G0.3,:","))') rescs_hdr
+           write (6095,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif
@@ -1000,7 +1000,7 @@
          if (pco%csvout == "y") then
            call open_output_file(6097, "wetland_cs_aa.csv", 2000)
            write (6097,*) bsn%name, prog
-           write (6097,'(*(G0.3,:","))') rescs_hdr
+           write (6097,'(*(G0.6,:","))') rescs_hdr
          endif
        endif
      endif 

--- a/src/header_hyd.f90
+++ b/src/header_hyd.f90
@@ -25,8 +25,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2584, "hydout_day.csv", 800)
             write (2584,*) bsn%name, prog
-            write (2584,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2584,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2584,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2584,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*) "HYDOUT                    hydout_day.csv"
           end if
       end if
@@ -40,8 +40,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2585, "hydout_mon.csv", 800)
             write (2585,*) bsn%name, prog
-            write (2585,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2585,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2585,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2585,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*) "HYDOUT                    hydout_mon.csv"
           end if
      end if
@@ -55,8 +55,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2586, "hydout_yr.csv", 800)
             write (2586,*) bsn%name, prog
-            write (2586,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2586,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2586,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2586,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*)   "HYDOUT                    hydout_yr.csv"
           end if
      end if
@@ -70,8 +70,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2587, "hydout_aa.csv", 800)
             write (2587,*) bsn%name, prog
-            write (2587,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2587,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2587,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2587,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*)   "HYDOUT                    hydout_aa.csv"
           end if
        end if
@@ -87,8 +87,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2564, "hydin_day.csv", 800)
             write (2564,*) bsn%name, prog
-            write (2564,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2564,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2564,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2564,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*) "HYDIN                     hydin_day.csv"
           end if
        endif
@@ -102,8 +102,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2565, "hydin_mon.csv", 800)
             write (2565,*) bsn%name, prog
-            write (2565,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2565,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2565,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2565,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*) "HYDIN                     hydin_mon.csv"
           end if
       endif
@@ -117,8 +117,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2566, "hydin_yr.csv", 800)
             write (2566,*) bsn%name, prog
-            write (2566,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2566,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2566,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2566,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*) "HYDIN                     hydin_yr.csv"
           end if
       endif
@@ -132,8 +132,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2567, "hydin_aa.csv", 800)
             write (2567,*) bsn%name, prog
-            write (2567,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
-            write (2567,'(*(G0.3,:","))') hyd_hdr_units2
+            write (2567,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr_obj, hyd_hdr
+            write (2567,'(*(G0.6,:","))') hyd_hdr_units2
             write (9000,*) "HYDIN                     hydin_aa.csv"
           end if
       endif
@@ -149,8 +149,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2704, "deposition_day.csv", 800)
             write (2704,*) bsn%name, prog
-            write (2704,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2704,'(*(G0.3,:","))') hyd_hdr_units
+            write (2704,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2704,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "DEPO                      deposition_day.csv"
           end if
       end if
@@ -165,8 +165,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2705, "deposition_mon.csv", 800)
             write (2705,*) bsn%name, prog
-            write (2705,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2705,'(*(G0.3,:","))') hyd_hdr_units
+            write (2705,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2705,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "DEPO                      deposition_mon.csv"
           end if
        end if
@@ -181,8 +181,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2706, "deposition_yr.csv", 800)
             write (2706,*) bsn%name, prog
-            write (2706,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2706,'(*(G0.3,:","))') hyd_hdr_units
+            write (2706,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2706,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "DEPO                      deposition_yr.csv"
           end if
        end if
@@ -197,8 +197,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2707, "deposition_aa.csv", 800)
             write (2707,*) bsn%name, prog
-            write (2707,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2707,'(*(G0.3,:","))') hyd_hdr_units
+            write (2707,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2707,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "DEPO                      deposition_aa.csv"
           end if
        end if

--- a/src/header_path.f90
+++ b/src/header_path.f90
@@ -18,7 +18,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2794, "hru_path_day.csv", 800)
             write (2794,*) bsn%name, prog
-            write (2794,'(*(G0.3,:","))') pathb_hdr
+            write (2794,'(*(G0.6,:","))') pathb_hdr
             write (9000,*) "HRU_PATH                  hru_path_day.csv"
           end if
       end if
@@ -33,7 +33,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2795, "hru_path_mon.csv", 800)
             write (2795,*) bsn%name, prog
-            write (2795,'(*(G0.3,:","))') pathb_hdr
+            write (2795,'(*(G0.6,:","))') pathb_hdr
             write (9000,*) "HRU_PATH                  hru_path_mon.csv"
           end if
       end if
@@ -48,7 +48,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2796, "hru_path_yr.csv", 800)
             write (2796,*) bsn%name, prog
-            write (2796,'(*(G0.3,:","))') pathb_hdr
+            write (2796,'(*(G0.6,:","))') pathb_hdr
             write (9000,*) "HRU_PATH                  hru_path_yr.csv"
           end if
       end if
@@ -63,7 +63,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2797, "hru_path_aa.csv", 800)
             write (2797,*) bsn%name, prog
-            write (2797,'(*(G0.3,:","))') pathb_hdr
+            write (2797,'(*(G0.6,:","))') pathb_hdr
             write (9000,*) "HRU_PATH                  hru_path_aa.csv"
           end if
       end if

--- a/src/header_pest.f90
+++ b/src/header_pest.f90
@@ -23,7 +23,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2804, "hru_pest_day.csv", 800)
             write (2804,*) bsn%name, prog
-            write (2804,'(*(G0.3,:","))') pestb_hdr
+            write (2804,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "HRU_PEST                  hru_pest_day.csv"
           end if
       end if
@@ -38,7 +38,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2805, "hru_pest_mon.csv", 800)
             write (2805,*) bsn%name, prog
-            write (2805,'(*(G0.3,:","))') pestb_hdr
+            write (2805,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "HRU_PEST                  hru_pest_mon.csv"
           end if
       end if
@@ -53,7 +53,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2806, "hru_pest_yr.csv", 800)
             write (2806,*) bsn%name, prog
-            write (2806,'(*(G0.3,:","))') pestb_hdr
+            write (2806,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "HRU_PEST                  hru_pest_yr.csv"
           end if
       end if
@@ -68,7 +68,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2807, "hru_pest_aa.csv", 800)
             write (2807,*) bsn%name, prog
-            write (2807,'(*(G0.3,:","))') pestb_hdr
+            write (2807,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "HRU_PEST                  hru_pest_aa.csv"
           end if
       end if
@@ -87,7 +87,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2812, "channel_pest_day.csv", 800)
             write (2812,*) bsn%name, prog
-            write (2812,'(*(G0.3,:","))') chpest_hdr
+            write (2812,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "CHANNEL_PEST              channel_pest_day.csv"
           end if
       end if
@@ -102,7 +102,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2813, "channel_pest_mon.csv", 800)
             write (2813,*) bsn%name, prog
-            write (2813,'(*(G0.3,:","))') chpest_hdr
+            write (2813,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "CHANNEL_PEST              channel_pest_mon.csv"
           end if
       end if
@@ -117,7 +117,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2814, "channel_pest_yr.csv", 800)
             write (2814,*) bsn%name, prog
-            write (2814,'(*(G0.3,:","))') chpest_hdr
+            write (2814,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "CHANNEL_PEST              channel_pest_yr.csv"
           end if
       end if
@@ -132,7 +132,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2815, "channel_pest_aa.csv", 800)
             write (2815,*) bsn%name, prog
-            write (2815,'(*(G0.3,:","))') chpest_hdr
+            write (2815,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "CHANNEL_PEST              channel_pest_aa.csv"
           end if
       end if
@@ -151,7 +151,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2820, "reservoir_pest_day.csv", 800)
             write (2820,*) bsn%name, prog
-            write (2820,'(*(G0.3,:","))') respest_hdr
+            write (2820,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "RESERVOIR_PEST            reservoir_pest_day.csv"           
           end if
       end if
@@ -166,7 +166,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2821, "reservoir_pest_mon.csv", 800)
             write (2821,*) bsn%name, prog
-            write (2821,'(*(G0.3,:","))') respest_hdr
+            write (2821,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "RESERVOIR_PEST            reservoir_pest_mon.csv"
           end if
       end if
@@ -181,7 +181,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2822, "reservoir_pest_yr.csv", 800)
             write (2822,*) bsn%name, prog
-            write (2822,'(*(G0.3,:","))') respest_hdr
+            write (2822,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "RESERVOIR_PEST            reservoir_pest_yr.csv"
           end if
       end if
@@ -196,7 +196,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2823, "reservoir_pest_aa.csv", 800)
             write (2823,*) bsn%name, prog
-            write (2823,'(*(G0.3,:","))') respest_hdr
+            write (2823,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "RESERVOIR_PEST            reservoir_pest_aa.csv"
           end if
       end if
@@ -215,7 +215,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3004, "basin_aqu_pest_day.csv", 800)
             write (3004,*) bsn%name, prog
-            write (3004,'(*(G0.3,:","))') aqupest_hdr
+            write (3004,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "BASIN_AQUIFER_PEST        basin_aqu_pest_day.csv"
           end if
       end if
@@ -230,7 +230,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3005, "basin_aqu_pest_mon.csv", 800)
             write (3005,*) bsn%name, prog
-            write (3005,'(*(G0.3,:","))') aqupest_hdr
+            write (3005,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "BASIN_AQUIFER_PEST        basin_aqu_pest_mon.csv"
           end if
       end if
@@ -245,7 +245,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3006, "basin_aqu_pest_yr.csv", 800)
             write (3006,*) bsn%name, prog
-            write (3006,'(*(G0.3,:","))') aqupest_hdr
+            write (3006,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "BASIN_AQUIFER_PEST        basin_aqu_pest_yr.csv" 
           end if
       end if
@@ -260,7 +260,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3007, "basin_aqu_pest_aa.csv", 800)
             write (3007,*) bsn%name, prog
-            write (3007,'(*(G0.3,:","))') aqupest_hdr
+            write (3007,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "BASIN_AQUIFER_PEST        basin_aqu_pest_aa.csv"
           end if
       end if
@@ -279,7 +279,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3012, "aquifer_pest_day.csv", 800)
             write (3012,*) bsn%name, prog
-            write (3012,'(*(G0.3,:","))') aqupest_hdr
+            write (3012,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "AQUIFER_PEST              aquifer_pest_day.csv"
           end if
       end if
@@ -294,7 +294,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3013, "aquifer_pest_mon.csv", 800)
             write (3013,*) bsn%name, prog
-            write (3013,'(*(G0.3,:","))') aqupest_hdr
+            write (3013,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "AQUIFER_PEST              aquifer_pest_mon.csv"
           end if
       end if
@@ -309,7 +309,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3014, "aquifer_pest_yr.csv", 800)
             write (3014,*) bsn%name, prog
-            write (3014,'(*(G0.3,:","))') aqupest_hdr
+            write (3014,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "AQUIFER_PEST              aquifer_pest_yr.csv"
           end if
       end if
@@ -324,7 +324,7 @@
           if (pco%csvout == "y") then
             call open_output_file(3015, "aquifer_pest_aa.csv", 800)
             write (3015,*) bsn%name, prog
-            write (3015,'(*(G0.3,:","))') aqupest_hdr
+            write (3015,'(*(G0.6,:","))') aqupest_hdr
             write (9000,*) "AQUIFER_PEST              aquifer_pest_aa.csv"
           end if
       end if
@@ -343,7 +343,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2836, "basin_ch_pest_day.csv", 800)
             write (2836,*) bsn%name, prog
-            write (2836,'(*(G0.3,:","))') chpest_hdr
+            write (2836,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "BASIN_CH_PEST             reservoir_pest_day.csv"
           end if
        end if
@@ -358,7 +358,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2837, "basin_ch_pest_mon.csv", 800)
             write (2837,*) bsn%name, prog
-            write (2837,'(*(G0.3,:","))') chpest_hdr
+            write (2837,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "BASIN_CH_PEST             basin_ch_pest_mon.csv"
           end if
       end if
@@ -373,7 +373,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2838, "basin_ch_pest_yr.csv", 800)
             write (2838,*) bsn%name, prog
-            write (2838,'(*(G0.3,:","))') chpest_hdr
+            write (2838,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "BASIN_CH_PEST             basin_ch_pest_yr.csv"
           end if
       end if
@@ -388,7 +388,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2839, "basin_ch_pest_aa.csv", 800)
             write (2839,*) bsn%name, prog
-            write (2839,'(*(G0.3,:","))') chpest_hdr
+            write (2839,'(*(G0.6,:","))') chpest_hdr
             write (9000,*) "BASIN_CH_PEST             basin_ch_pest_aa.csv"
           end if
       end if
@@ -407,7 +407,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2852, "basin_res_pest_day.csv", 800)
             write (2852,*) bsn%name, prog
-            write (2852,'(*(G0.3,:","))') respest_hdr
+            write (2852,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "BASIN_RES_PEST          reservoir_pest_day.csv"
           end if
        end if
@@ -422,7 +422,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2853, "basin_res_pest_mon.csv", 800)
             write (2853,*) bsn%name, prog
-            write (2853,'(*(G0.3,:","))') respest_hdr
+            write (2853,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "BASIN_RES_PEST            basin_res_pest_mon.csv" 
           end if
       end if
@@ -437,7 +437,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2854, "basin_res_pest_yr.csv", 800)
             write (2854,*) bsn%name, prog
-            write (2854,'(*(G0.3,:","))') respest_hdr
+            write (2854,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "BASIN_RES_PEST            basin_res_pest_yr.csv"
           end if
       end if
@@ -452,7 +452,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2855, "basin_res_pest_aa.csv", 800)
             write (2855,*) bsn%name, prog
-            write (2855,'(*(G0.3,:","))') respest_hdr
+            write (2855,'(*(G0.6,:","))') respest_hdr
             write (9000,*) "BASIN_RES_PEST            basin_res_pest_aa.csv"
           end if
       end if
@@ -471,7 +471,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2868, "basin_ls_pest_day.csv", 800)
             write (2868,*) bsn%name, prog
-            write (2868,'(*(G0.3,:","))') pestb_hdr
+            write (2868,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "BASIN_LS_PEST             basin_ls_pest_day.csv"
           end if
        end if
@@ -486,7 +486,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2869, "basin_ls_pest_mon.csv", 800)
             write (2869,*) bsn%name, prog
-            write (2869,'(*(G0.3,:","))') pestb_hdr
+            write (2869,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "BASIN_LS_PEST             basin_ls_pest_mon.csv"
           end if
       end if
@@ -501,7 +501,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2870, "basin_ls_pest_yr.csv", 800)
             write (2870,*) bsn%name, prog
-            write (2870,'(*(G0.3,:","))') pestb_hdr
+            write (2870,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "BASIN_LS_PEST             basin_ls_pest_yr.csv"
           end if
       end if
@@ -516,7 +516,7 @@
           if (pco%csvout == "y") then
             call open_output_file(2871, "basin_ls_pest_aa.csv", 800)
             write (2871,*) bsn%name, prog
-            write (2871,'(*(G0.3,:","))') pestb_hdr
+            write (2871,'(*(G0.6,:","))') pestb_hdr
             write (9000,*) "BASIN_LS_PEST             basin_ls_pest_aa.csv"
           end if
       end if

--- a/src/header_reservoir.f90
+++ b/src/header_reservoir.f90
@@ -20,8 +20,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2544, "reservoir_day.csv", 1500)
             write (2544,*) bsn%name, prog
-            write (2544,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2544,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2544,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2544,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (9000,*) "RES                       reservoir_day.csv"
           end if
       end if
@@ -35,8 +35,8 @@
            if (pco%csvout == "y") then
             call open_output_file(2545, "reservoir_mon.csv", 1500)
             write (2545,*) bsn%name, prog
-            write (2545,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2545,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2545,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2545,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (2545,*) "RES                       reservoir_mon.csv"
           end if
      end if
@@ -50,8 +50,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2546, "reservoir_yr.csv", 1500)
             write (2546,*) bsn%name, prog
-            write (2546,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2546,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2546,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2546,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (9000,*) "RES                       reservoir_yr.csv"
           end if
       end if
@@ -65,8 +65,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2547, "reservoir_aa.csv", 1500)
             write (2547,*) bsn%name, prog
-            write (2547,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2547,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2547,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2547,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (9000,*) "RES                       reservoir_aa.csv"
           end if
       end if

--- a/src/header_salt.f90
+++ b/src/header_salt.f90
@@ -217,7 +217,7 @@
          call open_output_file(5022, "hru_salt_day.csv", 3000)
          write (5022,*) bsn%name, prog
          write (5022,*) 'conc = mg/L; other = kg/ha'
-         write (5022,'(*(G0.3,:","))') salt_hdr_hru
+         write (5022,'(*(G0.6,:","))') salt_hdr_hru
        endif
      endif
      
@@ -257,7 +257,7 @@
          call open_output_file(5024, "hru_salt_mon.csv", 3000)
          write (5024,*) bsn%name, prog
          write (5024,*) 'conc = mg/L; other = kg/ha'
-         write (5024,'(*(G0.3,:","))') salt_hdr_hru
+         write (5024,'(*(G0.6,:","))') salt_hdr_hru
        endif
      endif
      
@@ -297,7 +297,7 @@
          call open_output_file(5026, "hru_salt_yr.csv", 3000)
          write (5026,*) bsn%name, prog
          write (5026,*) 'conc = mg/L; other = kg/ha'
-         write (5026,'(*(G0.3,:","))') salt_hdr_hru
+         write (5026,'(*(G0.6,:","))') salt_hdr_hru
        endif
      endif
      
@@ -337,7 +337,7 @@
          call open_output_file(5028, "hru_salt_aa.csv", 3000)
          write (5028,*) bsn%name, prog
          write (5028,*) 'conc = mg/L; other = kg/ha'
-         write (5028,'(*(G0.3,:","))') salt_hdr_hru
+         write (5028,'(*(G0.6,:","))') salt_hdr_hru
        endif
      endif
 
@@ -366,7 +366,7 @@
            call open_output_file(5061, "aquifer_salt_day.csv", 2000)
            write (5061,*) bsn%name, prog
            write (5061,*) 'conc = mg/L; other = kg'
-           write (5061,'(*(G0.3,:","))') salt_hdr_aqu
+           write (5061,'(*(G0.6,:","))') salt_hdr_aqu
          endif
        endif
      endif
@@ -396,7 +396,7 @@
            call open_output_file(5063, "aquifer_salt_mon.csv", 2000)
            write (5063,*) bsn%name, prog
            write (5063,*) 'conc = mg/L; other = kg'
-           write (5063,'(*(G0.3,:","))') salt_hdr_aqu
+           write (5063,'(*(G0.6,:","))') salt_hdr_aqu
          endif
        endif
      endif
@@ -426,7 +426,7 @@
            call open_output_file(5065, "aquifer_salt_yr.csv", 2000)
            write (5065,*) bsn%name, prog
            write (5065,*) 'conc = mg/L; other = kg'
-           write (5065,'(*(G0.3,:","))') salt_hdr_aqu
+           write (5065,'(*(G0.6,:","))') salt_hdr_aqu
          endif
        endif
      endif
@@ -456,7 +456,7 @@
            call open_output_file(5067, "aquifer_salt_aa.csv", 2000)
            write (5067,*) bsn%name, prog
            write (5067,*) 'conc = mg/L; other = kg'
-           write (5067,'(*(G0.3,:","))') salt_hdr_aqu
+           write (5067,'(*(G0.6,:","))') salt_hdr_aqu
          endif
        endif
      endif
@@ -485,7 +485,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5031, "channel_salt_day.csv", 2000)
            write (5031,*) bsn%name, prog
-           write (5031,'(*(G0.3,:","))') chsalt_hdr
+           write (5031,'(*(G0.6,:","))') chsalt_hdr
          endif
        endif
      endif
@@ -514,7 +514,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5033, "channel_salt_mon.csv", 2000)
            write (5033,*) bsn%name, prog
-           write (5033,'(*(G0.3,:","))') chsalt_hdr
+           write (5033,'(*(G0.6,:","))') chsalt_hdr
          endif
        endif
      endif
@@ -543,7 +543,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5035, "channel_salt_yr.csv", 2000)
            write (5035,*) bsn%name, prog
-           write (5035,'(*(G0.3,:","))') chsalt_hdr
+           write (5035,'(*(G0.6,:","))') chsalt_hdr
          endif
        endif
      endif
@@ -572,7 +572,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5037, "channel_salt_aa.csv", 2000)
            write (5037,*) bsn%name, prog
-           write (5037,'(*(G0.3,:","))') chsalt_hdr
+           write (5037,'(*(G0.6,:","))') chsalt_hdr
          endif
        endif
      endif
@@ -602,7 +602,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5041, "reservoir_salt_day.csv", 2000)
            write (5041,*) bsn%name, prog
-           write (5041,'(*(G0.3,:","))') ressalt_hdr
+           write (5041,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif
@@ -632,7 +632,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5043, "reservoir_salt_mon.csv", 2000)
            write (5043,*) bsn%name, prog
-           write (5043,'(*(G0.3,:","))') ressalt_hdr
+           write (5043,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif
@@ -662,7 +662,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5045, "reservoir_salt_yr.csv", 2000)
            write (5045,*) bsn%name, prog
-           write (5045,'(*(G0.3,:","))') ressalt_hdr
+           write (5045,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif
@@ -692,7 +692,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5047, "reservoir_salt_aa.csv", 2000)
            write (5047,*) bsn%name, prog
-           write (5047,'(*(G0.3,:","))') ressalt_hdr
+           write (5047,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif 
@@ -730,7 +730,7 @@
            call open_output_file(5071, "rout_unit_salt_day.csv", 2000)
            write (5071,*) bsn%name, prog
            write (5071,*) 'all values in kg'
-           write (5071,'(*(G0.3,:","))') rusaltb_hdr
+           write (5071,'(*(G0.6,:","))') rusaltb_hdr
          endif
        endif
      endif
@@ -768,7 +768,7 @@
            call open_output_file(5073, "rout_unit_salt_mon.csv", 2000)
            write (5073,*) bsn%name, prog
            write (5073,*) 'all values in kg'
-           write (5073,'(*(G0.3,:","))') rusaltb_hdr
+           write (5073,'(*(G0.6,:","))') rusaltb_hdr
          endif
        endif
      endif
@@ -806,7 +806,7 @@
            call open_output_file(5075, "rout_unit_salt_yr.csv", 2000)
            write (5075,*) bsn%name, prog
            write (5075,*) 'all values in kg'
-           write (5075,'(*(G0.3,:","))') rusaltb_hdr
+           write (5075,'(*(G0.6,:","))') rusaltb_hdr
          endif
        endif
      endif
@@ -844,7 +844,7 @@
            call open_output_file(5077, "rout_unit_salt_aa.csv", 2000)
            write (5077,*) bsn%name, prog
            write (5077,*) 'all values in kg'
-           write (5077,'(*(G0.3,:","))') rusaltb_hdr
+           write (5077,'(*(G0.6,:","))') rusaltb_hdr
          endif
        endif
      endif 
@@ -874,7 +874,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5091, "wetland_salt_day.csv", 2000)
            write (5091,*) bsn%name, prog
-           write (5091,'(*(G0.3,:","))') ressalt_hdr
+           write (5091,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif
@@ -904,7 +904,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5093, "wetland_salt_mon.csv", 2000)
            write (5093,*) bsn%name, prog
-           write (5093,'(*(G0.3,:","))') ressalt_hdr
+           write (5093,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif
@@ -934,7 +934,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5095, "wetland_salt_yr.csv", 2000)
            write (5095,*) bsn%name, prog
-           write (5095,'(*(G0.3,:","))') ressalt_hdr
+           write (5095,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif
@@ -964,7 +964,7 @@
          if (pco%csvout == "y") then
            call open_output_file(5097, "wetland_salt_aa.csv", 2000)
            write (5097,*) bsn%name, prog
-           write (5097,'(*(G0.3,:","))') ressalt_hdr
+           write (5097,'(*(G0.6,:","))') ressalt_hdr
          endif
        endif
      endif

--- a/src/header_sd_channel.f90
+++ b/src/header_sd_channel.f90
@@ -20,8 +20,8 @@
           if (pco%csvout == "y") then
             call open_output_file(4814, "channel_sd_subday.csv", 1500)
             write (4814,*) bsn%name, prog
-            write (4814,'(*(G0.3,:,","))') sdch_hdr 
-            write (4814,'(*(G0.3,:,","))') sdch_hdr_units_sub
+            write (4814,'(*(G0.6,:,","))') sdch_hdr 
+            write (4814,'(*(G0.6,:,","))') sdch_hdr_units_sub
             write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_subday.csv"
           end if
            end if         
@@ -40,14 +40,14 @@
           if (pco%csvout == "y") then
             call open_output_file(2504, "channel_sd_day.csv", 1500)
             write (2504,*) bsn%name, prog
-            write (2504,'(*(G0.3,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
-            write (2504,'(*(G0.3,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units 
+            write (2504,'(*(G0.6,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
+            write (2504,'(*(G0.6,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units 
             write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_day.csv"
             
             !call open_output_file(2510, "channel_sd_day_new.csv", 1500)
             !write (2510,*) bsn%name, prog
-            !write (2510,'(*(G0.3,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
-            !write (2510,'(*(G0.3,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
+            !write (2510,'(*(G0.6,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
+            !write (2510,'(*(G0.6,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
             !write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_day_new.csv"                  
           end if
         endif
@@ -70,14 +70,14 @@
           if (pco%csvout == "y") then
             call open_output_file(2505, "channel_sd_mon.csv", 1500)
             write (2505,*) bsn%name, prog
-            write (2505,'(*(G0.3,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
-            write (2505,'(*(G0.3,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units 
+            write (2505,'(*(G0.6,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
+            write (2505,'(*(G0.6,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units 
             write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_mon.csv"
             
            !call open_output_file(3512, "channel_sd_mon_new.csv", 1500)
             !write (3512,*) bsn%name, prog
-            !write (3512,'(*(G0.3,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
-            !write (3512,'(*(G0.3,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
+            !write (3512,'(*(G0.6,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
+            !write (3512,'(*(G0.6,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
             !write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_mon_new.csv"    
           end if
           end if
@@ -100,14 +100,14 @@
           if (pco%csvout == "y") then
             call open_output_file(2506, "channel_sd_yr.csv", 1500)
             write (2506,*) bsn%name, prog
-            write (2506,'(*(G0.3,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
-            write (2506,'(*(G0.3,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units 
+            write (2506,'(*(G0.6,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
+            write (2506,'(*(G0.6,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units 
             write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_yr.csv"
             
           !call open_output_file(3514, "channel_sd_yr_new.csv", 1500)
           !  write (3514,*) bsn%name, prog
-          !  write (3514,'(*(G0.3,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
-          !  write (3514,'(*(G0.3,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
+          !  write (3514,'(*(G0.6,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
+          !  write (3514,'(*(G0.6,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
           !  write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_yr_new.csv"    
           end if
         endif
@@ -130,14 +130,14 @@
           if (pco%csvout == "y") then
             call open_output_file(2507, "channel_sd_aa.csv", 1500)
             write (2507,*) bsn%name, prog
-            write (2507,'(*(G0.3,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
-            write (2507,'(*(G0.3,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units
+            write (2507,'(*(G0.6,:,","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr, wtmp_hdr
+            write (2507,'(*(G0.6,:,","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1, wtmp_units
             write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_aa.csv"
             
           !call open_output_file(3516, "channel_sd_aa_new.csv", 1500)
           !  write (3516,*) bsn%name, prog
-          !  write (3516,'(*(G0.3,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
-          !  write (3516,'(*(G0.3,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
+          !  write (3516,'(*(G0.6,:,","))') ch_wbod_inouthdr, hyd_inout_hdr
+          !  write (3516,'(*(G0.6,:,","))') ch_wbod_inouthdr_units, hydinout_hdr_units1
           !  write (9000,*) "SWAT-DEG_CHANNEL          channel_sd_aa_new.csv"
             
           end if
@@ -155,8 +155,8 @@
           if (pco%csvout == "y") then
             call open_output_file(4804, "channel_sdmorph_day.csv", 1500)
             write (4804,*) bsn%name, prog
-            write (4804,'(*(G0.3,:,","))') sdch_hdr 
-            write (4804,'(*(G0.3,:,","))') sdch_hdr_units
+            write (4804,'(*(G0.6,:,","))') sdch_hdr 
+            write (4804,'(*(G0.6,:,","))') sdch_hdr_units
             write (9000,*) "SWAT-DEG_CHANNEL_MORPH    channel_sdmorph_day.csv"
           end if
         endif
@@ -170,10 +170,10 @@
           write (4801,*) sdch_hdr_units
           write (9000,*) "SWAT-DEG_CHANNEL_MORPH    channel_sdmorph_mon.txt"
           if (pco%csvout == "y") then
-            call open_output_file(4805, "channel_mon_sdmorph.csv", 1500)
+            call open_output_file(4805, "channel_sdmorph_mon.csv", 1500)
             write (4805,*) bsn%name, prog
-            write (4805,'(*(G0.3,:,","))') sdch_hdr   
-            write (4805,'(*(G0.3,:,","))') sdch_hdr_units
+            write (4805,'(*(G0.6,:,","))') sdch_hdr   
+            write (4805,'(*(G0.6,:,","))') sdch_hdr_units
             write (9000,*) "SWAT-DEG_CHANNEL_MORPH    channel_sdmorph_mon.csv"
           end if
           end if
@@ -189,8 +189,8 @@
           if (pco%csvout == "y") then
             call open_output_file(4806, "channel_sdmorph_yr.csv", 1500)
             write (4806,*) bsn%name, prog
-            write (4806,'(*(G0.3,:,","))') sdch_hdr !! swat deg channel morph csv
-            write (4806,'(*(G0.3,:,","))') sdch_hdr_units
+            write (4806,'(*(G0.6,:,","))') sdch_hdr !! swat deg channel morph csv
+            write (4806,'(*(G0.6,:,","))') sdch_hdr_units
             write (9000,*) "SWAT-DEG_CHANNEL_MORPH    channel_sdmorph_yr.csv"
           end if
         endif
@@ -206,8 +206,8 @@
           if (pco%csvout == "y") then
             call open_output_file(4807, "channel_sdmorph_aa.csv", 1500)
             write (4807,*) bsn%name, prog
-            write (4807,'(*(G0.3,:,","))') sdch_hdr   
-            write (4807,'(*(G0.3,:,","))') sdch_hdr_units
+            write (4807,'(*(G0.6,:,","))') sdch_hdr   
+            write (4807,'(*(G0.6,:,","))') sdch_hdr_units
             write (9000,*) "SWAT-DEG_CHANNEL_MORPH    channel_sdmorph_aa.csv"
           end if
           end if
@@ -224,8 +224,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4812, "sd_chanbud_day.csv", 1500)
             write (4812,*) bsn%name, prog
-            write (4812,'(*(G0.3,:","))') sdch_bud_hdr
-            write (4812,'(*(G0.3,:","))') sdch_bud_hdr_units        
+            write (4812,'(*(G0.6,:","))') sdch_bud_hdr
+            write (4812,'(*(G0.6,:","))') sdch_bud_hdr_units        
             write (9000,*) "SWAT_DEG_CHAN_BUD         sd_chanbud_day.csv"
           end if
         endif
@@ -239,8 +239,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(4813, "sd_chanbud_mon.csv", 1500)
            write (4813,*) bsn%name, prog
-           write (4813,'(*(G0.3,:","))') sdch_bud_hdr 
-           write (4813,'(*(G0.3,:","))') sdch_bud_hdr_units        
+           write (4813,'(*(G0.6,:","))') sdch_bud_hdr 
+           write (4813,'(*(G0.6,:","))') sdch_bud_hdr_units        
            write (9000,*) "SWAT_DEG_CHAN_BUD         sd_chanbud_mon.csv"
          end if
         end if
@@ -254,8 +254,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4814, "sd_chanbud_yr.csv", 1500)
             write (4814,*) bsn%name, prog
-            write (4814,'(*(G0.3,:","))') sdch_bud_hdr
-            write (4814,'(*(G0.3,:","))') sdch_bud_hdr_units        
+            write (4814,'(*(G0.6,:","))') sdch_bud_hdr
+            write (4814,'(*(G0.6,:","))') sdch_bud_hdr_units        
             write (9000,*) "SWAT_DEG_CHAN_BUD         sd_chanbud_yr.csv"
           end if
         endif
@@ -269,8 +269,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4815, "sd_chanbud_aa.csv", 1500)
             write (4815,*) bsn%name, prog
-            write (4815,'(*(G0.3,:","))') sdch_bud_hdr 
-            write (4815,'(*(G0.3,:","))') sdch_bud_hdr_units 
+            write (4815,'(*(G0.6,:","))') sdch_bud_hdr 
+            write (4815,'(*(G0.6,:","))') sdch_bud_hdr_units 
             write (9000,*) "SWAT_DEG_CHAN_BUD         sd_chanbud_aa.csv"
           end if
         end if

--- a/src/header_water_allocation.f90
+++ b/src/header_water_allocation.f90
@@ -18,8 +18,8 @@
           if (pco%csvout == "y") then
             call open_output_file(3114, "water_allo_day.csv", 1500)
             write (3114,*) bsn%name, prog
-            write (3114,'(*(G0.3,:,","))') wallo_hdr
-            write (3114,'(*(G0.3,:,","))') wallo_hdr_units
+            write (3114,'(*(G0.6,:,","))') wallo_hdr
+            write (3114,'(*(G0.6,:,","))') wallo_hdr_units
             write (9000,*) "WATER_ALLOCATION          water_allo_day.csv"
           end if
         endif
@@ -35,8 +35,8 @@
           if (pco%csvout == "y") then
             call open_output_file(3115, "water_allo_mon.csv", 1500)
             write (3115,*) bsn%name, prog
-            write (3115,'(*(G0.3,:,","))') wallo_hdr
-            write (3115,'(*(G0.3,:,","))') wallo_hdr_units
+            write (3115,'(*(G0.6,:,","))') wallo_hdr
+            write (3115,'(*(G0.6,:,","))') wallo_hdr_units
             write (9000,*) "WATER_ALLOCATION          water_allo_mon.csv"
           end if
           end if
@@ -52,8 +52,8 @@
           if (pco%csvout == "y") then
             call open_output_file(3116, "water_allo_yr.csv", 1500)
             write (3116,*) bsn%name, prog
-            write (3116,'(*(G0.3,:,","))') wallo_hdr
-            write (3116,'(*(G0.3,:,","))') wallo_hdr_units
+            write (3116,'(*(G0.6,:,","))') wallo_hdr
+            write (3116,'(*(G0.6,:,","))') wallo_hdr_units
             write (9000,*) "WATER_ALLOCATION          water_allo_yr.csv"
           end if
         endif
@@ -69,8 +69,8 @@
           if (pco%csvout == "y") then
             call open_output_file(3117, "water_allo_aa.csv", 1500)
             write (3117,*) bsn%name, prog
-            write (3117,'(*(G0.3,:,","))') wallo_hdr
-            write (3117,'(*(G0.3,:,","))') wallo_hdr_units
+            write (3117,'(*(G0.6,:,","))') wallo_hdr
+            write (3117,'(*(G0.6,:,","))') wallo_hdr_units
             write (9000,*) "WATER_ALLOCATION          water_allo_aa.csv"
           end if
           end if

--- a/src/header_wetland.f90
+++ b/src/header_wetland.f90
@@ -17,8 +17,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2552, "wetland_day.csv", 1500)
             write (2552,*) bsn%name, prog
-            write (2552,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2552,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2552,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2552,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (9000,*) "RES_WET                   wetland_day.csv"
           end if
       end if
@@ -33,8 +33,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2553, "wetland_mon.csv", 1500)
             write (2553,*) bsn%name, prog
-            write (2553,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2553,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3 
+            write (2553,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2553,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3 
             write (9000,*) "RES_WET                   wetland_mon.csv"
           end if
       end if
@@ -49,8 +49,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2554, "wetland_yr.csv", 1500)
             write (2554,*) bsn%name, prog
-            write (2554,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2554,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2554,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2554,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (9000,*) "RES_WET                   wetland_yr.csv"
           end if
      end if
@@ -66,9 +66,9 @@
           if (pco%csvout == "y") then
             call open_output_file(2555, "wetland_aa.csv", 1500)
             write (2555,*) bsn%name, prog
-            write (2555,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2555,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
-            !write (2555,'(*(G0.3,:","))') res_hdr_add
+            write (2555,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2555,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            !write (2555,'(*(G0.6,:","))') res_hdr_add
             write (9000,*) "RES_WET                   wetland_aa.csv"
           end if
       end if

--- a/src/header_write.f90
+++ b/src/header_write.f90
@@ -65,8 +65,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2094, "basin_aqu_day.csv", 1500)
             write (2094,*) bsn%name, prog
-            write (2094,'(*(G0.3,:","))') aqu_hdr
-            write (2094,'(*(G0.3,:","))') aqu_hdr_units
+            write (2094,'(*(G0.6,:","))') aqu_hdr
+            write (2094,'(*(G0.6,:","))') aqu_hdr_units
             write (9000,*) "BASIN_AQUIFER             basin_aqu_day.csv"
           end if
         endif
@@ -80,8 +80,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(2095, "basin_aqu_mon.csv", 1500)
            write (2095,*) bsn%name, prog
-           write (2095,'(*(G0.3,:","))') aqu_hdr
-           write (2095,'(*(G0.3,:","))') aqu_hdr_units
+           write (2095,'(*(G0.6,:","))') aqu_hdr
+           write (2095,'(*(G0.6,:","))') aqu_hdr_units
            write (9000,*) "BASIN_AQUIFER             basin_aqu_mon.csv"
          end if
       end if 
@@ -95,8 +95,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(2096, "basin_aqu_yr.csv", 1500)
            write (2096,*) bsn%name, prog
-           write (2096,'(*(G0.3,:","))') aqu_hdr 
-           write (2096,'(*(G0.3,:","))') aqu_hdr_units
+           write (2096,'(*(G0.6,:","))') aqu_hdr 
+           write (2096,'(*(G0.6,:","))') aqu_hdr_units
            write (9000,*) "BASIN_AQUIFER             basin_aqu_yr.csv"
          end if
       end if 
@@ -110,8 +110,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(2097, "basin_aqu_aa.csv", 1500)
            write (2097,*) bsn%name, prog
-           write (2097,'(*(G0.3,:","))') aqu_hdr 
-           write (2097,'(*(G0.3,:","))') aqu_hdr_units
+           write (2097,'(*(G0.6,:","))') aqu_hdr 
+           write (2097,'(*(G0.6,:","))') aqu_hdr_units
            write (9000,*) "BASIN_AQUIFER             basin_aqu_aa.csv"
          end if
       end if 
@@ -127,8 +127,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2104, "basin_res_day.csv", 1500)
             write (2104,*) bsn%name, prog
-            write (2104,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2104,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2104,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2104,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (9000,*) "BASIN_RESERVOIR           basin_res_day.csv"
           end if
         endif
@@ -142,8 +142,8 @@
        if (pco%csvout == "y") then 
           call open_output_file(2105, "basin_res_mon.csv", 1500)
           write (2105,*) bsn%name, prog
-          write (2105,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-          write (2105,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+          write (2105,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+          write (2105,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
           write (9000,*) "BASIN_RESERVOIR           basin_res_mon.csv"
        end if
       end if
@@ -157,8 +157,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2106, "basin_res_yr.csv", 1500)
             write (2106,*) bsn%name, prog
-            write (2106,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (2106,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+            write (2106,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (2106,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
             write (9000,*) "BASIN_RESERVOIR           basin_res_yr.csv"
           end if
        endif
@@ -172,8 +172,8 @@
        if (pco%csvout == "y") then 
           call open_output_file(2107, "basin_res_aa.csv", 1500)
           write (2107,*) bsn%name, prog
-          write (2107,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-          write (2107,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
+          write (2107,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+          write (2107,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units3, hyd_hdr_units3
           write (9000,*) "BASIN_RESERVOIR           basin_res_aa.csv"
        end if
       end if
@@ -189,8 +189,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4604, "recall_day.csv", 1500)
             write (4604,*) bsn%name, prog
-            write (4604,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr 
-            write (4604,'(*(G0.3,:","))') hyd_hdr_units3
+            write (4604,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr 
+            write (4604,'(*(G0.6,:","))') hyd_hdr_units3
             write (9000,*) "RECALL                    recall_day.csv"
           end if
         endif
@@ -204,8 +204,8 @@
          if (pco%csvout == "y") then 
             call open_output_file(4605, "recall_mon.csv", 1500)
             write (4605,*) bsn%name, prog
-            write (4605,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr 
-            write (4605,'(*(G0.3,:","))') hyd_hdr_units3
+            write (4605,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr 
+            write (4605,'(*(G0.6,:","))') hyd_hdr_units3
             write (9000,*) "RECALL                    recall_mon.csv"
          end if
        end if
@@ -219,8 +219,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4606, "recall_yr.csv", 1500)
             write (4606,*) bsn%name, prog
-            write (4606,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr 
-            write (4606,'(*(G0.3,:","))') hyd_hdr_units3
+            write (4606,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr 
+            write (4606,'(*(G0.6,:","))') hyd_hdr_units3
             write (9000,*) "RECALL                    recall_yr.csv"
           end if
         endif
@@ -234,8 +234,8 @@
          if (pco%csvout == "y") then 
             call open_output_file(4607, "recall_aa.csv", 1500)
             write (4607,*) bsn%name, prog
-            write (4607,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr 
-            write (4607,'(*(G0.3,:","))') hyd_hdr_units3
+            write (4607,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr 
+            write (4607,'(*(G0.6,:","))') hyd_hdr_units3
             write (9000,*) "RECALL                    recall_aa.csv"
          end if
         end if
@@ -252,8 +252,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2114, "basin_cha_day.csv", 1500)
             write (2114,*) bsn%name, prog
-            write (2114,'(*(G0.3,:","))') ch_hdr
-            write (2114,'(*(G0.3,:","))') ch_hdr_units
+            write (2114,'(*(G0.6,:","))') ch_hdr
+            write (2114,'(*(G0.6,:","))') ch_hdr_units
             write (9000,*) "BASIN_CHANNEL             basin_cha_day.txt"
           end if
         endif
@@ -267,8 +267,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(2115, "basin_cha_mon.csv", 1500)
            write (2115,*) bsn%name, prog
-           write (2115,'(*(G0.3,:","))') ch_hdr 
-           write (2115,'(*(G0.3,:","))') ch_hdr_units
+           write (2115,'(*(G0.6,:","))') ch_hdr 
+           write (2115,'(*(G0.6,:","))') ch_hdr_units
            write (9000,*) "BASIN_CHANNEL             basin_cha_mon.txt"
          end if
         end if
@@ -282,8 +282,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2116, "basin_cha_yr.csv", 1500)
             write (2116,*) bsn%name, prog
-            write (2116,'(*(G0.3,:","))') ch_hdr
-            write (2116,'(*(G0.3,:","))') ch_hdr_units
+            write (2116,'(*(G0.6,:","))') ch_hdr
+            write (2116,'(*(G0.6,:","))') ch_hdr_units
             write (9000,*) "BASIN_CHANNEL             basin_cha_yr.csv"
           end if
         endif
@@ -297,8 +297,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2117, "basin_cha_aa.csv", 1500)
             write (2117,*) bsn%name, prog
-            write (2117,'(*(G0.3,:","))') ch_hdr
-            write (2117,'(*(G0.3,:","))') ch_hdr_units
+            write (2117,'(*(G0.6,:","))') ch_hdr
+            write (2117,'(*(G0.6,:","))') ch_hdr_units
             write (9000,*) "BASIN_CHANNEL             basin_cha_aa.csv"
           end if
         end if
@@ -314,8 +314,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4904, "basin_sd_cha_day.csv", 1500)
             write (4904,*) bsn%name, prog
-            write (4904,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (4904,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1 
+            write (4904,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (4904,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1 
             write (9000,*) "BASIN_SWAT_DEG_CHANNEL    basin_sd_cha_day.csv"
           end if
         endif
@@ -329,8 +329,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(4905, "basin_sd_cha_mon.csv", 1500)
            write (4905,*) bsn%name, prog
-           write (4905,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-           write (4905,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1
+           write (4905,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+           write (4905,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1
            write (9000,*) "BASIN_SWAT_DEG_CHANNEL    basin_sd_cha_mon.csv"
          end if
         end if
@@ -344,8 +344,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4906, "basin_sd_cha_yr.csv", 1500)
             write (4906,*) bsn%name, prog
-            write (4906,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (4906,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1 
+            write (4906,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (4906,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1 
             write (9000,*) "BASIN_SWAT_DEG_CHANNEL    basin_sd_cha_yr.csv"
           end if
         endif
@@ -359,8 +359,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4907, "basin_sd_cha_aa.csv", 1500)
             write (4907,*) bsn%name, prog
-            write (4907,'(*(G0.3,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
-            write (4907,'(*(G0.3,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1
+            write (4907,'(*(G0.6,:","))') ch_wbod_hdr, hyd_stor_hdr, hyd_in_hdr, hyd_out_hdr
+            write (4907,'(*(G0.6,:","))') ch_wbod_hdr_units, hyd_hdr_units3, hyd_hdr_units1, hyd_hdr_units1
             write (9000,*) "BASIN_SWAT_DEG_CHANNEL    basin_sd_cha_aa.csv"
           end if
         end if
@@ -377,8 +377,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2124, "basin_sd_chamorph_day.csv", 1500)
             write (2124,*) bsn%name, prog
-            write (2124,'(*(G0.3,:","))') sdch_hdr
-            write (2124,'(*(G0.3,:","))') sdch_hdr_units        
+            write (2124,'(*(G0.6,:","))') sdch_hdr
+            write (2124,'(*(G0.6,:","))') sdch_hdr_units        
             write (9000,*) "BASIN_SWAT_DEG_CHAN_MORPH basin_sd_chamorph_day.csv"
           end if
         endif
@@ -392,8 +392,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(2125, "basin_sd_chamorph_mon.csv", 1500)
            write (2125,*) bsn%name, prog
-           write (2125,'(*(G0.3,:","))') sdch_hdr 
-           write (2125,'(*(G0.3,:","))') sdch_hdr_units        
+           write (2125,'(*(G0.6,:","))') sdch_hdr 
+           write (2125,'(*(G0.6,:","))') sdch_hdr_units        
            write (9000,*) "BASIN_SWAT_DEG_CHAN_MORPH basin_sd_chamorph_mon.csv"
          end if
         end if
@@ -407,8 +407,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2126, "basin_sd_chamorph_yr.csv", 1500)
             write (2126,*) bsn%name, prog
-            write (2126,'(*(G0.3,:","))') sdch_hdr
-            write (2126,'(*(G0.3,:","))') sdch_hdr_units        
+            write (2126,'(*(G0.6,:","))') sdch_hdr
+            write (2126,'(*(G0.6,:","))') sdch_hdr_units        
             write (9000,*) "BASIN_SWAT_DEG_CHAN_MORPH basin_sd_chamorph_yr.csv"
           end if
         endif
@@ -422,8 +422,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2127, "basin_sd_chamorph_aa.csv", 1500)
             write (2127,*) bsn%name, prog
-            write (2127,'(*(G0.3,:","))') sdch_hdr 
-            write (2127,'(*(G0.3,:","))') sdch_hdr_units 
+            write (2127,'(*(G0.6,:","))') sdch_hdr 
+            write (2127,'(*(G0.6,:","))') sdch_hdr_units 
             write (9000,*) "BASIN_SWAT_DEG_CHAN_MORPH basin_sd_chamorph_aa.csv"
           end if
         end if
@@ -439,8 +439,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2132, "basin_sd_chanbud_day.csv", 1500)
             write (2132,*) bsn%name, prog
-            write (2132,'(*(G0.3,:","))') sdch_bud_hdr
-            write (2132,'(*(G0.3,:","))') sdch_bud_hdr_units        
+            write (2132,'(*(G0.6,:","))') sdch_bud_hdr
+            write (2132,'(*(G0.6,:","))') sdch_bud_hdr_units        
             write (9000,*) "BASIN_SWAT_DEG_CHAN_BUD   basin_sd_chanbud_day.csv"
           end if
         endif
@@ -454,8 +454,8 @@
          if (pco%csvout == "y") then 
            call open_output_file(2133, "basin_sd_chanbud_mon.csv", 1500)
            write (2133,*) bsn%name, prog
-           write (2133,'(*(G0.3,:","))') sdch_bud_hdr 
-           write (2133,'(*(G0.3,:","))') sdch_bud_hdr_units        
+           write (2133,'(*(G0.6,:","))') sdch_bud_hdr 
+           write (2133,'(*(G0.6,:","))') sdch_bud_hdr_units        
            write (9000,*) "BASIN_SWAT_DEG_CHAN_BUD   basin_sd_chanbud_mon.csv"
          end if
         end if
@@ -469,8 +469,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2134, "basin_sd_chanbud_yr.csv", 1500)
             write (2134,*) bsn%name, prog
-            write (2134,'(*(G0.3,:","))') sdch_bud_hdr
-            write (2134,'(*(G0.3,:","))') sdch_bud_hdr_units        
+            write (2134,'(*(G0.6,:","))') sdch_bud_hdr
+            write (2134,'(*(G0.6,:","))') sdch_bud_hdr_units        
             write (9000,*) "BASIN_SWAT_DEG_CHAN_BUD   basin_sd_chanbud_yr.csv"
           end if
         endif
@@ -484,8 +484,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2135, "basin_sd_chanbud_aa.csv", 1500)
             write (2135,*) bsn%name, prog
-            write (2135,'(*(G0.3,:","))') sdch_bud_hdr 
-            write (2135,'(*(G0.3,:","))') sdch_bud_hdr_units 
+            write (2135,'(*(G0.6,:","))') sdch_bud_hdr 
+            write (2135,'(*(G0.6,:","))') sdch_bud_hdr_units 
             write (9000,*) "BASIN_SWAT_DEG_CHAN_BUD   basin_sd_chanbud_aa.csv"
           end if
         end if
@@ -502,8 +502,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4504, "basin_psc_day.csv", 1500)
             write (4504,*) bsn%name, prog
-            write (4504,'(*(G0.3,:","))') rec_hdr_time, hyd_hdr 
-            write (4504,'(*(G0.3,:","))') hyd_hdr_units
+            write (4504,'(*(G0.6,:","))') rec_hdr_time, hyd_hdr 
+            write (4504,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "BASIN_RECALL              basin_psc_day.csv"
           end if
         endif
@@ -517,8 +517,8 @@
          if (pco%csvout == "y") then 
             call open_output_file(4505, "basin_psc_mon.csv", 1500)
             write (4505,*) bsn%name, prog
-            write (4505,'(*(G0.3,:","))') rec_hdr_time, hyd_hdr 
-            write (4505,'(*(G0.3,:","))') hyd_hdr_units
+            write (4505,'(*(G0.6,:","))') rec_hdr_time, hyd_hdr 
+            write (4505,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "BASIN_RECALL              basin_psc_mon.csv"
          end if
        end if
@@ -532,8 +532,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(4506, "basin_psc_yr.csv", 1500)
             write (4506,*) bsn%name, prog
-            write (4506,'(*(G0.3,:","))') rec_hdr_time, hyd_hdr 
-            write (4506,'(*(G0.3,:","))') hyd_hdr_units
+            write (4506,'(*(G0.6,:","))') rec_hdr_time, hyd_hdr 
+            write (4506,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "BASIN_RECALL              basin_psc_yr.csv"
           end if
         endif
@@ -547,8 +547,8 @@
          if (pco%csvout == "y") then 
             call open_output_file(4507, "basin_psc_aa.csv", 1500)
             write (4507,*) bsn%name, prog
-            write (4507,'(*(G0.3,:","))') rec_hdr_time, hyd_hdr 
-            write (4507,'(*(G0.3,:","))') hyd_hdr_units
+            write (4507,'(*(G0.6,:","))') rec_hdr_time, hyd_hdr 
+            write (4507,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "BASIN_RECALL_AA           basin_psc_aa.csv"
          end if
         end if
@@ -565,8 +565,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2604, "ru_day.csv", 1500)
             write (2604,*) bsn%name, prog
-            write (2604,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2604,'(*(G0.3,:","))') hyd_hdr_units
+            write (2604,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2604,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "ROUTING_UNITS             ru_day.csv"
           end if
         endif
@@ -580,8 +580,8 @@
         if (pco%csvout == "y") then 
             call open_output_file(2605, "ru_mon.csv", 1500)
             write (2605,*) bsn%name, prog
-            write (2605,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2605,'(*(G0.3,:","))') hyd_hdr_units
+            write (2605,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2605,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "ROUTING_UNITS             ru_mon.csv"
          end if
        end if
@@ -595,8 +595,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2606, "ru_yr.csv", 1500)
             write (2606,*) bsn%name, prog
-            write (2606,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2606,'(*(G0.3,:","))') hyd_hdr_units
+            write (2606,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2606,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "ROUTING_UNITS             ru_yr.csv"
           end if
         endif
@@ -610,8 +610,8 @@
          if (pco%csvout == "y") then 
             call open_output_file(2607, "ru_aa.csv", 1500)
             write (2607,*) bsn%name, prog
-            write (2607,'(*(G0.3,:","))') hyd_hdr_time, hyd_hdr
-            write (2607,'(*(G0.3,:","))') hyd_hdr_units
+            write (2607,'(*(G0.6,:","))') hyd_hdr_time, hyd_hdr
+            write (2607,'(*(G0.6,:","))') hyd_hdr_units
             write (9000,*) "ROUTING_UNITS             ru_aa.csv"
          end if
         end if

--- a/src/hru_carbon_output.f90
+++ b/src/hru_carbon_output.f90
@@ -36,10 +36,10 @@
         write (4550,*) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_d(j)   !! soil transformations
 
         if (pco%csvout == "y") then
-          write (4524,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_d(j)    !! soil carbon gain/loss
-          write (4534,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_d(j)    !! residue carbon gain/loss
-          write (4544,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_d(j)    !! plant carbon gain/loss
-          write (4554,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_d(j)   !! soil transformations
+          write (4524,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_d(j)    !! soil carbon gain/loss
+          write (4534,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_d(j)    !! residue carbon gain/loss
+          write (4544,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_d(j)    !! plant carbon gain/loss
+          write (4554,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_d(j)   !! soil transformations
 
         end if
       end if
@@ -59,10 +59,10 @@
           write (4551,*) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_m(j)   !! soil transformations
 
           if (pco%csvout == "y") then
-            write (4525,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_m(j)    !! soil carbon gain/loss
-            write (4535,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_m(j)    !! residue carbon gain/loss
-            write (4545,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_m(j)    !! plant carbon gain/loss
-            write (4555,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_m(j)   !! soil transformations
+            write (4525,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_m(j)    !! soil carbon gain/loss
+            write (4535,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_m(j)    !! residue carbon gain/loss
+            write (4545,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_m(j)    !! plant carbon gain/loss
+            write (4555,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_m(j)   !! soil transformations
 
           end if
         end if
@@ -87,10 +87,10 @@
           write (4552,*) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_y(j)   !! soil transformations
 
           if (pco%csvout == "y") then
-          write (4526,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_y(j)    !! soil carbon gain/loss
-          write (4536,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_y(j)    !! residue carbon gain/loss
-          write (4546,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_y(j)    !! plant carbon gain/loss
-          write (4556,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_y(j)   !! soil transformations
+          write (4526,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_y(j)    !! soil carbon gain/loss
+          write (4536,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_y(j)    !! residue carbon gain/loss
+          write (4546,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_y(j)    !! plant carbon gain/loss
+          write (4556,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_y(j)   !! soil transformations
 
           end if
         end if
@@ -113,10 +113,10 @@
           write (4553,*) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_a(j)   !! soil transformations
 
           if (pco%csvout == "y") then 
-            write (4527,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_a(j)    !! soil carbon gain/loss
-            write (4537,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_a(j)    !! residue carbon gain/loss
-            write (4547,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_a(j)    !! plant carbon gain/loss
-            write (4557,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_a(j)   !! soil transformations
+            write (4527,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hsc_a(j)    !! soil carbon gain/loss
+            write (4537,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hrc_a(j)    !! residue carbon gain/loss
+            write (4547,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpc_a(j)    !! plant carbon gain/loss
+            write (4557,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hscf_a(j)   !! soil transformations
 
           end if
           hsc_a(j) = hscz

--- a/src/hru_cs_output.f90
+++ b/src/hru_cs_output.f90
@@ -68,7 +68,7 @@
                          (hcsb_d(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                          (hcsb_d(j)%cs(ics)%srbd,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6022,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (6022,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                                                              (hcsb_d(j)%cs(ics)%soil,ics=1,cs_db%num_cs), & 
                                          (hcsb_d(j)%cs(ics)%surq,ics=1,cs_db%num_cs), &
                                          (hcsb_d(j)%cs(ics)%sedm,ics=1,cs_db%num_cs), &
@@ -147,7 +147,7 @@
                            (hcsb_m(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                            (hcsb_m(j)%cs(ics)%srbd,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6024,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (6024,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                          (hcsb_m(j)%cs(ics)%soil,ics=1,cs_db%num_cs), & 
                                          (hcsb_m(j)%cs(ics)%surq,ics=1,cs_db%num_cs), &
                                          (hcsb_m(j)%cs(ics)%sedm,ics=1,cs_db%num_cs), &
@@ -249,7 +249,7 @@
                            (hcsb_y(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                            (hcsb_y(j)%cs(ics)%srbd,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6026,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (6026,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                          (hcsb_y(j)%cs(ics)%soil,ics=1,cs_db%num_cs), & 
                                          (hcsb_y(j)%cs(ics)%surq,ics=1,cs_db%num_cs), &
                                          (hcsb_y(j)%cs(ics)%sedm,ics=1,cs_db%num_cs), &
@@ -344,7 +344,7 @@
                         (hcsb_a(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                         (hcsb_a(j)%cs(ics)%srbd,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6028,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (6028,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (hcsb_a(j)%cs(ics)%soil,ics=1,cs_db%num_cs), & 
                                         (hcsb_a(j)%cs(ics)%surq,ics=1,cs_db%num_cs), &
                                         (hcsb_a(j)%cs(ics)%sedm,ics=1,cs_db%num_cs), &

--- a/src/hru_lte_output.f90
+++ b/src/hru_lte_output.f90
@@ -23,27 +23,27 @@
           if (pco%wb_sd%d == "y") then
             write (2300,100) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltwb_d(isd)  !! waterbal
               if (pco%csvout == "y") then 
-                write (2304,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                write (2304,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltwb_d(isd)  !! waterbal
               end if 
           end if
 !          if (pco%nb_sd%d == "y") then
 !            write (2420,100) time%day, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_d(isd)  !! nutrient bal
 !             if (pco%csvout == "y") then 
-!               write (2424,'(*(G0.3,:","))') time%day, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_d(isd)  !! nutrient bal
+!               write (2424,'(*(G0.6,:","))') time%day, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_d(isd)  !! nutrient bal
 !             end if 
 !          end if
           if (pco%ls_sd%d == "y") then
             write (2440,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltls_d(isd)  !! losses
               if (pco%csvout == "y") then 
-                write (2444,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                write (2444,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltls_d(isd)  !! losses
               endif 
           end if
           if (pco%pw_sd%d == "y") then
             write (2460,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltpw_d(isd)  !! plant weather 
               if (pco%csvout == "y") then 
-                write (2464,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                write (2464,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltpw_d(isd)  !! plant weather 
               end if 
           end if
@@ -64,27 +64,27 @@
            if (pco%wb_sd%m == "y") then
              write (2301,100) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltwb_m(isd)
                if (pco%csvout == "y") then 
-                 write (2305,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2305,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltwb_m(isd)
                end if 
            end if
 !           if (pco%nb_sd%m == "y") then
 !             write (2421,100) time%mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_m(isd)
 !             if (pco%csvout == "y") then 
-!               write (2425,'(*(G0.3,:","))') time%mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_m(isd)
+!               write (2425,'(*(G0.6,:","))') time%mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_m(isd)
 !             end if 
 !           end if
            if (pco%ls_sd%m == "y") then
              write (2441,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltls_m(isd)
                if (pco%csvout == "y") then 
-                 write (2445,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2445,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltls_m(isd)
                end if 
            end if
            if (pco%pw_sd%m == "y") then
              write (2461,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltpw_m(isd)
                if (pco%csvout == "y") then 
-                 write (2465,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2465,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltpw_m(isd)
                end if 
            end if
@@ -110,27 +110,27 @@
            if (time%end_yr == 1 .and. pco%wb_sd%y == "y") then
              write (2302,100) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltwb_y(isd)
                 if (pco%csvout == "y") then 
-                  write (2306,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                  write (2306,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltwb_y(isd)
                 end if 
            end if
 !           if (time%end_yr == 1 .and. pco%nb_sd%y == "y") then
 !             write (2422,100) time%end_yr, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_y(isd)
 !             if (pco%csvout == "y") then 
-!               write (2426,'(*(G0.3,:","))') time%end_yr, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_y(isd)
+!               write (2426,'(*(G0.6,:","))') time%end_yr, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_y(isd)
 !             end if 
 !           end if
            if (time%end_yr == 1 .and. pco%ls_sd%y == "y") then
              write (2442,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltls_y(isd)
                if (pco%csvout == "y") then 
-                 write (2446,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2446,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltls_y(isd)
                end if 
            end if
            if (time%end_yr == 1 .and. pco%pw_sd%y == "y") then
              write (2462,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltpw_y(isd)
               if (pco%csvout == "y") then 
-                write (2466,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+                write (2466,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                     hltpw_y(isd)
               end if 
            end if
@@ -143,7 +143,7 @@
            hltwb_a(isd) = hltwb_a(isd) // time%days_prt          
            write (2303,100) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltwb_a(isd)
            if (pco%csvout == "y") then 
-             write (2307,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+             write (2307,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                 hltwb_a(isd)
            end if
            hltwb_a(isd) = hwbz
@@ -153,7 +153,7 @@
 !           hltnb_a(isd) = hltnb_a(isd) / time%yrs_prt
 !           write (2423,100) time%end_yr, time%yrs, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_a(isd)
 !         if (pco%csvout == "y") then 
-!             write (2427,'(*(G0.3,:","))') time%end_yr, time%yrs, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_a(isd)
+!             write (2427,'(*(G0.6,:","))') time%end_yr, time%yrs, isd, ob(iob)%gis_id, ob(iob)%name, hltnb_a(isd)
 !           end if
 !         end if
 !         hltnb_a(isd) = hnbz       
@@ -162,7 +162,7 @@
            hltls_a(isd) = hltls_a(isd) / time%yrs_prt  
            write (2443,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltls_a(isd)
            if (pco%csvout == "y") then 
-             write (2447,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+             write (2447,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                 hltls_a(isd)
            end if
          end if
@@ -173,7 +173,7 @@
            hltpw_a(isd) = hltpw_a(isd) // time%days_prt
            write (2463,101) time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, hltpw_a(isd)
            if (pco%csvout == "y") then 
-             write (2467,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
+             write (2467,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, isd, ob(iob)%gis_id, ob(iob)%name, &
                 hltpw_a(isd)
            end if
            hltpw_a(isd) = hpwz

--- a/src/hru_output.f90
+++ b/src/hru_output.f90
@@ -63,7 +63,7 @@
                                                                            lum(ilu)%plant_cov, lum(ilu)%mgt_ops     !! water bal day
              if (pco%csvout == "y") then
                !! changed write unit below (2004 to write file data)
-               write (2004,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2004,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                     hwb_d(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops  
              end if
           end if
@@ -74,7 +74,7 @@
             write (2020,104) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hnb_d(j),         &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops      !! nutrient bal day
             if (pco%csvout == "y") then
-                write (2024,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                write (2024,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                     hnb_d(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops  
                 end if
           end if
@@ -82,7 +82,7 @@
             write (2030,108) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hls_d(j),         &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops, hpw_d(j)%percn       !! losses day
             if (pco%csvout == "y") then
-                write (2034,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                write (2034,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                     hls_d(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops, hpw_d(j)%percn   
             end if
           end if
@@ -91,7 +91,7 @@
             write (2040,101) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpw_d(j),                  & 
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops  !! plant weather day 
               if (pco%csvout == "y") then 
-                write (2044,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,           &
+                write (2044,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,           &
                                                                 hpw_d(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops  
               end if 
           end if
@@ -121,7 +121,7 @@
              write (2001,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hwb_m(j),        &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops           !! water bal mon
                if (pco%csvout == "y") then
-                 write (2005,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2005,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                           hwb_m(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops 
                end if
            end if
@@ -130,7 +130,7 @@
              write (2021,104) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hnb_m(j),        &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops           !! nutrient bal mon
              if (pco%csvout == "y") then
-                 write (2025,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2025,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                           hnb_m(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops 
                  end if
            end if
@@ -139,7 +139,7 @@
              write (2031,108) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hls_m(j),        &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops, hpw_m(j)%percn            !! losses mon
              if (pco%csvout == "y") then 
-                 write (2035,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2035,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                           hls_m(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops, hpw_m(j)%percn  
              end if
            end if
@@ -150,7 +150,7 @@
              write (2041,101) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpw_m(j),         &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops  !! plant weather mon
                if (pco%csvout == "y") then 
-                 write (2045,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,  &
+                 write (2045,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,  &
                                                                 hpw_m(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops  
                end if 
            end if
@@ -192,7 +192,7 @@
              write (2002,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hwb_y(j),          &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops           !! water balance yr
                if (pco%csvout == "y") then
-                 write (2006,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,   &
+                 write (2006,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,   &
                                                                           hwb_y(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops 
                end if
           end if
@@ -201,7 +201,7 @@
              write (2022,104) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hnb_y(j),          &
                                                                                 lum(ilu)%plant_cov, lum(ilu)%mgt_ops     !! nutrient balance yr
              if (pco%csvout == "y") then
-                 write (2026,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,   &
+                 write (2026,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,   &
                                                                           hnb_y(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops 
                  end if
            end if
@@ -210,7 +210,7 @@
              write (2032,108) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hls_y(j),          &
                                                                            lum(ilu)%plant_cov, lum(ilu)%mgt_ops, hpw_y(j)%percn            !! losses yr
              if (pco%csvout == "y") then
-                 write (2036,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,   &
+                 write (2036,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,   &
                                                                           hls_y(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops, hpw_y(j)%percn  
              end if
            end if
@@ -221,7 +221,7 @@
              write (2042,101) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpw_y(j),        &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops  !! plant weather yr             
                if (pco%csvout == "y") then 
-                 write (2046,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2046,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                 hpw_y(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops  
                end if 
            end if
@@ -244,7 +244,7 @@
              write (2003,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hwb_a(j),       &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops       !! water balance ann
              if (pco%csvout == "y") then
-               write (2007,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,  &
+               write (2007,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,  &
                                                                         hwb_a(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops
              end if
            end if
@@ -266,7 +266,7 @@
            write (2023,104) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hnb_a(j),        &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops      !! nutrient bal ann
            if (pco%csvout == "y") then 
-               write (2027,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2027,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                         hnb_a(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops
                end if
              hnb_a(j) = hnbz
@@ -278,7 +278,7 @@
            write (2033,107) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hls_a(j),        &
                                                                           lum(ilu)%plant_cov, lum(ilu)%mgt_ops, percn_aa       !! losses ann
              if (pco%csvout == "y") then 
-               write (2037,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2037,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                                                                         hls_a(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops, percn_aa 
              end if
              hls_a(j) = hlsz
@@ -293,7 +293,7 @@
            write (2043,102) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpw_a(j),           &
                                                                         lum(ilu)%plant_cov, lum(ilu)%mgt_ops  !! plant weather ann
              if (pco%csvout == "y") then 
-               write (2047,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,    &
+               write (2047,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name,    &
                                                               hpw_a(j), lum(ilu)%plant_cov, lum(ilu)%mgt_ops  
              end if
              hru(j)%strsa = hpw_a(j)%strsa
@@ -316,7 +316,7 @@
               endif
               write (4008,103) time%day, time%mo, time%day_mo, time%yrc, j,pldb(idp)%plantnm, pl_mass(j)%yield_tot(ipl)
               if (pco%csvout == "y") then
-                write (4009,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j,pldb(idp)%plantnm, pl_mass(j)%yield_tot(ipl) 
+                write (4009,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j,pldb(idp)%plantnm, pl_mass(j)%yield_tot(ipl) 
               end if
             end do
            end if

--- a/src/hru_pathogen_output.f90
+++ b/src/hru_pathogen_output.f90
@@ -34,7 +34,7 @@
           if (pco%wb_hru%d == "y") then
              write (2790,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpath_bal(j)%path(ipath)   !! pathogen balance
              if (pco%csvout == "y") then
-               write (2794,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2794,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                  hpath_bal(j)%path(ipath)
              end if
           end if
@@ -55,7 +55,7 @@
            if (pco%wb_hru%m == "y") then
              write (2791,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpathb_m(j)%path(ipath)
                if (pco%csvout == "y") then
-                 write (2795,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2795,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    hpathb_m(j)%path(ipath)
                end if
            end if
@@ -77,7 +77,7 @@
            if (time%end_yr == 1 .and. pco%wb_hru%y == "y") then
              write (2792,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, hpathb_y(j)%path(ipath)
                if (pco%csvout == "y") then
-                 write (2796,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2796,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    hpathb_y(j)%path(ipath)
                end if
            end if

--- a/src/hru_pesticide_output.f90
+++ b/src/hru_pesticide_output.f90
@@ -35,7 +35,7 @@
              write (2800,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                hpestb_d(j)%pest(ipest)   !! pesticide balance
              if (pco%csvout == "y") then
-               write (2804,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2804,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                  cs_db%pests(ipest), hpestb_d(j)%pest(ipest)
              end if
           end if
@@ -54,7 +54,7 @@
              write (2801,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                hpestb_m(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2805,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2805,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    cs_db%pests(ipest), hpestb_m(j)%pest(ipest)
                end if
            end if
@@ -73,7 +73,7 @@
              write (2802,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                hpestb_y(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2806,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2806,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                    cs_db%pests(ipest), hpestb_y(j)%pest(ipest)
                end if
            end if
@@ -87,7 +87,7 @@
            write (2803,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
              hpestb_a(j)%pest(ipest)
            if (pco%csvout == "y") then
-             write (2807,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+             write (2807,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                cs_db%pests(ipest), hpestb_a(j)%pest(ipest)
            end if
            hpestb_a(j)%pest(ipest) = pestbz

--- a/src/hru_salt_output.f90
+++ b/src/hru_salt_output.f90
@@ -66,7 +66,7 @@
                          (hsaltb_d(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                           hsaltb_d(j)%salt(1)%diss
         if (pco%csvout == "y") then
-          write (5022,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (5022,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                                                             (hsaltb_d(j)%salt(isalt)%soil,isalt=1,cs_db%num_salts), &
                                         (hsaltb_d(j)%salt(isalt)%surq,isalt=1,cs_db%num_salts), &
                                         (hsaltb_d(j)%salt(isalt)%latq,isalt=1,cs_db%num_salts), &
@@ -141,7 +141,7 @@
                            (hsaltb_m(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             hsaltb_m(j)%salt(1)%diss
           if (pco%csvout == "y") then
-            write (5024,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (5024,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (hsaltb_m(j)%salt(isalt)%soil,isalt=1,cs_db%num_salts), &
                                           (hsaltb_m(j)%salt(isalt)%surq,isalt=1,cs_db%num_salts), &
                                           (hsaltb_m(j)%salt(isalt)%latq,isalt=1,cs_db%num_salts), &
@@ -238,7 +238,7 @@
                            (hsaltb_y(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             hsaltb_y(j)%salt(1)%diss
           if (pco%csvout == "y") then
-            write (5026,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (5026,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (hsaltb_y(j)%salt(isalt)%soil,isalt=1,cs_db%num_salts), &
                                           (hsaltb_y(j)%salt(isalt)%surq,isalt=1,cs_db%num_salts), &
                                           (hsaltb_y(j)%salt(isalt)%latq,isalt=1,cs_db%num_salts), &
@@ -328,7 +328,7 @@
                          (hsaltb_a(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                          hsaltb_a(j)%salt(1)%diss
         if (pco%csvout == "y") then
-          write (5028,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (5028,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (hsaltb_a(j)%salt(isalt)%soil,isalt=1,cs_db%num_salts), &
                                         (hsaltb_a(j)%salt(isalt)%surq,isalt=1,cs_db%num_salts), &
                                         (hsaltb_a(j)%salt(isalt)%latq,isalt=1,cs_db%num_salts), &

--- a/src/hyd_connect_out.f90
+++ b/src/hyd_connect_out.f90
@@ -25,7 +25,7 @@
            ob(icmd)%obtypno_out(i), ob(icmd)%htyp_out(i), i = 1,        &
            ob(icmd)%src_tot)
           if (pco%csvout == "y") then 
-            write (7001,'(*(G0.3,:","))') ii, ob(icmd)%name, ob(icmd)%typ,  &  
+            write (7001,'(*(G0.6,:","))') ii, ob(icmd)%name, ob(icmd)%typ,  &  
             ob(icmd)%props, ob(icmd)%props2, ob(icmd)%src_tot,              &
              ob(icmd)%rcv_tot, (ob(icmd)%obj_out,ob(icmd)%obtyp_out(i),     &
              ob(icmd)%obtypno_out(i), ob(icmd)%htyp_out(i), i = 1,          &

--- a/src/hyddep_output.f90
+++ b/src/hyddep_output.f90
@@ -20,7 +20,7 @@
         if (pco%hyd%d == "y") then
             write (2700,*) time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, ht1
           if (pco%csvout == "y") then
-            write (2704,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, ht1
+            write (2704,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, ht1
           end if 
         endif
       end if
@@ -33,7 +33,7 @@
             write (2701,*) time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,     &
               ob(icmd)%hdep_m
           if (pco%csvout == "y") then
-            write (2705,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,     &
+            write (2705,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,     &
               ob(icmd)%hdep_m
           end if
         end if
@@ -48,7 +48,7 @@
               ob(icmd)%hdep_y
  !                         ob(icmd)%hin_y
           if (pco%csvout == "y") then
-            write (2706,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,     &
+            write (2706,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,     &
              ob(icmd)%hdep_y
 !                          ob(icmd)%hin_y
           end if 
@@ -63,7 +63,7 @@
           write (2703,*) time%day, time%mo, time%day_mo, time%yrc,   ob(icmd)%name,      &
              ob(icmd)%typ, ob(icmd)%hdep_a
            if (pco%csvout == "y") then
-             write (2707,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,      &
+             write (2707,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,      &
               ob(icmd)%typ, ob(icmd)%hdep_a
            end if 
         end if

--- a/src/hydin_output.f90
+++ b/src/hydin_output.f90
@@ -22,7 +22,7 @@
 !            write (2560,*) time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, ob(icmd)%obtyp_in(iin),        &
 !              ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin), ob(icmd)%hin_d(iin)
               if (pco%csvout == "y") then
-                write (2564,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, &
+                write (2564,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, &
                  ob(icmd)%obtyp_in(iin), ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin),     &
                  ob(icmd)%hin_d(iin)
               end if       
@@ -38,7 +38,7 @@
             write (2561,*) time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, ob(icmd)%obtyp_in(iin),        &
              ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin), ob(icmd)%hin_m(iin)
               if (pco%csvout == "y") then
-                write (2565,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, &
+                write (2565,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, &
                     ob(icmd)%obtyp_in(iin), ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin),  &
                     ob(icmd)%hin_m(iin)
               end if
@@ -53,7 +53,7 @@
             write (2562,*) time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,  ob(icmd)%typ, ob(icmd)%obtyp_in(iin), &
              ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin), ob(icmd)%hin_y(iin)
             if (pco%csvout == "y") then
-              write (2566,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,  ob(icmd)%typ, ob(icmd)%num, &
+              write (2566,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,  ob(icmd)%typ, ob(icmd)%num, &
               ob(icmd)%obtyp_in(iin), ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin), ob(icmd)%hin_y(iin)
             endif
           end if
@@ -67,7 +67,7 @@
           write (2563,*) time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,  ob(icmd)%typ,  ob(icmd)%obtyp_in(iin), &
              ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin), ob(icmd)%hin_a(iin)
             if (pco%csvout == "y") then
-              write (2567,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, &
+              write (2567,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, &
                 ob(icmd)%obtyp_in(iin), ob(icmd)%obtypno_in(iin), ob(icmd)%htyp_in(iin), ob(icmd)%frac_in(iin), ob(icmd)%hin_a(iin)
             end if
         end if

--- a/src/hydout_output.f90
+++ b/src/hydout_output.f90
@@ -24,7 +24,7 @@
              ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),           &
              ob(icmd)%frac_out(iout), ht1
             if (pco%csvout == "y") then
-              write (2584,'(*(G0.3,:","))')time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,   &
+              write (2584,'(*(G0.6,:","))')time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,   &
                ob(icmd)%obtyp_out(iout),                              &
                ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),                   &
                ob(icmd)%frac_out(iout), ht1  
@@ -41,7 +41,7 @@
            ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),           &
            ob(icmd)%frac_out(iout), ob(icmd)%hout_m(iout)
             if (pco%csvout == "y") then
-              write (2585,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, & 
+              write (2585,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ, & 
              ob(icmd)%obtyp_out(iout),                              &
              ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),                   &
              ob(icmd)%frac_out(iout), ob(icmd)%hout_m(iout)
@@ -60,7 +60,7 @@
            ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),           &
            ob(icmd)%frac_out(iout), ob(icmd)%hout_y(iout)
              if (pco%csvout == "y") then
-               write (2586,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,  &
+               write (2586,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name, ob(icmd)%typ,  &
                ob(icmd)%obtyp_out(iout),                              &
                ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),                   &
                ob(icmd)%frac_out(iout), ob(icmd)%hout_y(iout)
@@ -78,7 +78,7 @@
            ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),           &
            ob(icmd)%frac_out(iout), ob(icmd)%hout_a(iout)
             if (pco%csvout == "y") then
-              write (2587,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,    &
+              write (2587,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(icmd)%name,    &
               ob(icmd)%typ, ob(icmd)%obtyp_out(iout),                   &
               ob(icmd)%obtypno_out(iout), ob(icmd)%htyp_out(iout),                      &
               ob(icmd)%frac_out(iout), ob(icmd)%hout_a(iout)

--- a/src/lsreg_output.f90
+++ b/src/lsreg_output.f90
@@ -114,7 +114,7 @@
             write (4412,100) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rwb_d(ireg)%lum(ilum)  !! waterbal
              if (pco%csvout == "y") then
-               write (4413,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
+               write (4413,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rwb_d(ireg)%lum(ilum)  !! waterbal
              end if
           end if
@@ -122,7 +122,7 @@
             write (4414,100) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rnb_d(ireg)%lum(ilum)  !! nutrient bal
               if (pco%csvout == "y") then
-                write (4415,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
+                write (4415,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
                     region(ireg)%lum_ha(ilum), rnb_d(ireg)%lum(ilum)  !! nutrient bal
               end if
           end if
@@ -130,7 +130,7 @@
             write (4416,102) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rls_d(ireg)%lum(ilum)  !! losses
               if (pco%csvout == "y") then
-                write (4417,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
+                write (4417,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
                     region(ireg)%lum_ha(ilum), rls_d(ireg)%lum(ilum)  !! losses
               end if
           end if
@@ -138,7 +138,7 @@
             write (4418,101) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rpw_d(ireg)%lum(ilum)  !! plant weather 
               if (pco%csvout == "y") then 
-                write (4419,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
+                write (4419,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
                     region(ireg)%lum_ha(ilum), rpw_d(ireg)%lum(ilum)  !! plant weather
               end if 
           end if
@@ -162,7 +162,7 @@
              write (4412,100) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rwb_m(ireg)%lum(ilum)
                if (pco%csvout == "y") then
-                 write (4413,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4413,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rwb_m(ireg)%lum(ilum)
                end if
            end if
@@ -170,7 +170,7 @@
              write (4414,100) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rnb_m(ireg)%lum(ilum)
                if (pco%csvout == "y") then
-                 write (4415,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4415,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rnb_m(ireg)%lum(ilum)
                end if
            end if
@@ -178,7 +178,7 @@
              write (4416,102) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rls_m(ireg)%lum(ilum)
                if (pco%csvout == "y") then 
-                 write (4417,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4417,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rls_m(ireg)%lum(ilum)
                end if
            end if
@@ -186,7 +186,7 @@
              write (4418,101) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rpw_m(ireg)%lum(ilum)
                if (pco%csvout == "y") then 
-                 write (4419,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4419,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rpw_m(ireg)%lum(ilum)
                end if 
            end if
@@ -219,7 +219,7 @@
              write (4412,100) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rwb_y(ireg)%lum(ilum)
                if (pco%csvout == "y") then
-                 write (4413,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4413,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rwb_y(ireg)%lum(ilum)
                end if
            end if
@@ -227,7 +227,7 @@
              write (4414,100) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rnb_y(ireg)%lum(ilum)
                if (pco%csvout == "y") then
-                 write (4415,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4415,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rnb_y(ireg)%lum(ilum)
                end if
            end if
@@ -235,7 +235,7 @@
              write (4416,102) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rls_y(ireg)%lum(ilum)
                if (pco%csvout == "y") then
-                 write (4417,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4417,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rls_y(ireg)%lum(ilum)
                end if
            end if
@@ -243,7 +243,7 @@
              write (4418,101) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,  &
                  region(ireg)%lum_ha(ilum), rpw_y(ireg)%lum(ilum)
                if (pco%csvout == "y") then 
-                 write (4419,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
+                 write (4419,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,&
                     region(ireg)%lum_ha(ilum), rpw_y(ireg)%lum(ilum)
                end if 
            end if
@@ -299,7 +299,7 @@
            write (4422,100) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,    &
               region(ireg)%lum_ha_tot(ilum), rnb_a(ireg)%lum(ilum)
              if (pco%csvout == "y") then 
-               write (4423,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
+               write (4423,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
                 region(ireg)%lum_ha_tot(ilum), rnb_a(ireg)%lum(ilum)
              end if
              rnb_a(ireg)%lum(ilum) = hnbz
@@ -310,7 +310,7 @@
            write (4424,101) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,    &
               region(ireg)%lum_ha_tot(ilum), rls_a(ireg)%lum(ilum)
              if (pco%csvout == "y") then 
-               write (4425,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
+               write (4425,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
                 region(ireg)%lum_ha_tot(ilum), rls_a(ireg)%lum(ilum)
              end if
              rls_a(ireg)%lum(ilum) = hlsz
@@ -321,7 +321,7 @@
            write (4426,102) time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov,   &
               region(ireg)%lum_ha_tot(ilum), rpw_a(ireg)%lum(ilum)
              if (pco%csvout == "y") then 
-               write (4427,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
+               write (4427,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, region(ireg)%name, lum(ilum_db)%plant_cov, &
                 region(ireg)%lum_ha_tot(ilum), rpw_a(ireg)%lum(ilum)
              end if
              rpw_a(ireg)%lum(ilum) = hpwz

--- a/src/lsu_output.f90
+++ b/src/lsu_output.f90
@@ -71,7 +71,7 @@
             ruwb_d(ilsu)%snopack = (ruwb_d(ilsu)%sno_init + ruwb_d(ilsu)%sno_final) / 2.
             write (2140,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_d(ilsu)  !! waterbal
             if (pco%csvout == "y") then 
-              write (2144,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2144,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_d(ilsu)  !! waterbal
             end if 
             ruwb_d(ilsu)%sw_init = ruwb_d(ilsu)%sw_final
@@ -80,21 +80,21 @@
           if (pco%nb_lsu%d == "y") then
             write (2150,103) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_d(ilsu)  !! nutrient bal
             if (pco%csvout == "y") then 
-              write (2154,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2154,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_d(ilsu)  !! nutrient bal
             end if 
           end if
           if (pco%ls_lsu%d == "y") then
             write (2160,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_d(ilsu)  !! losses
             if (pco%csvout == "y") then 
-              write (2164,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2164,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_d(ilsu)  !! losses
             end if 
           end if
           if (pco%pw_lsu%d == "y") then
             write (2170,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_d(ilsu)  !! plant weather
             if (pco%csvout == "y") then 
-              write (2175,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2175,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_d(ilsu)  !! plant weather 
             end if
           end if 
@@ -116,7 +116,7 @@
             ruwb_m(ilsu)%sno_final = ruwb_d(ilsu)%sno_final
             write (2141,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_m(ilsu)
             if (pco%csvout == "y") then 
-              write (2145,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2145,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_m(ilsu)
             end if
             ruwb_m(ilsu)%sw_init = ruwb_m(ilsu)%sw_final
@@ -125,14 +125,14 @@
           if (pco%nb_lsu%m == "y") then 
             write (2151,103) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_m(ilsu)
             if (pco%csvout == "y") then 
-              write (2155,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2155,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_m(ilsu)
             end if 
           end if
           if (pco%ls_lsu%m == "y") then
             write (2161,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_m(ilsu)
             if (pco%csvout == "y") then 
-              write (2165,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2165,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_m(ilsu)
             end if 
           end if
@@ -141,7 +141,7 @@
             rupw_m(ilsu)%pplnt = rupw_d(ilsu)%pplnt
             write (2171,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_m(ilsu)
             if (pco%csvout == "y") then 
-              write (2175,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+              write (2175,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_m(ilsu)
             end if 
           end if
@@ -171,7 +171,7 @@
              ruwb_y(ilsu)%sno_final = ruwb_d(ilsu)%sno_final
              write (2142,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_y(ilsu)
              if (pco%csvout == "y") then 
-               write (2146,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+               write (2146,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_y(ilsu)
              end if
              ruwb_y(ilsu)%sw_init = ruwb_y(ilsu)%sw_final
@@ -180,14 +180,14 @@
            if (pco%nb_lsu%y == "y") then
              write (2152,103) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_y(ilsu)
              if (pco%csvout == "y") then 
-               write (2156,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+               write (2156,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_y(ilsu)
              end if 
            end if
            if (pco%ls_lsu%y == "y") then
              write (2162,102) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_y(ilsu)
              if (pco%csvout == "y") then 
-               write (2166,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+               write (2166,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_y(ilsu)
              end if 
            end if
@@ -196,7 +196,7 @@
              rupw_y(ilsu)%pplnt = rupw_d(ilsu)%pplnt
              write (2172,102) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_y(ilsu)
              if (pco%csvout == "y") then 
-               write (2176,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, &
+               write (2176,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, &
                 ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_y(ilsu)
              end if 
            end if
@@ -225,21 +225,21 @@
         
         write (2143,100) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_a(ilsu)
         if (pco%csvout == "y") then 
-          write (2147,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_a(ilsu)
+          write (2147,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruwb_a(ilsu)
         end if 
       end if
       if (time%end_sim == 1 .and. pco%nb_lsu%a == "y") then
         runb_a(ilsu) = runb_a(ilsu) / time%yrs_prt
         write (2153,103) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_a(ilsu)
         if (pco%csvout == "y") then 
-          write (2157,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_a(ilsu)
+          write (2157,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, runb_a(ilsu)
         end if
       end if
       if (time%end_sim == 1 .and. pco%ls_lsu%a == "y") then     
         ruls_a(ilsu) = ruls_a(ilsu) / time%yrs_prt
         write (2163,102) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_a(ilsu)
         if (pco%csvout == "y") then 
-          write (2167,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_a(ilsu)
+          write (2167,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, ruls_a(ilsu)
         end if 
       end if
       if (time%end_sim == 1 .and. pco%pw_lsu%a == "y") then    
@@ -249,7 +249,7 @@
         rupw_a(ilsu)%pplnt = rupw_d(ilsu)%pplnt
         write (2173,102) time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_a(ilsu) 
         if (pco%csvout == "y") then 
-          write (2177,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_a(ilsu)
+          write (2177,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ilsu, ob(iob)%gis_id, lsu_out(ilsu)%name, rupw_a(ilsu)
         end if
       end if
       end do    !ilsu

--- a/src/manure_demand_output.f90
+++ b/src/manure_demand_output.f90
@@ -26,7 +26,7 @@
               isrc = 1, mallo(imallo)%src_obs)  
 
            if (pco%csvout == "y") then
-          write (3211,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
+          write (3211,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
               mallo(imallo)%trn(itrn)%ob_num, (mallo(imallo)%src(isrc)%num, mallo(imallo)%src(isrc)%mois_typ,   &
               mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%trn(itrn)%withdr(isrc),                         &
               isrc = 1, mallo(imallo)%src_obs)  
@@ -53,7 +53,7 @@
               isrc = 1, mallo(imallo)%src_obs) 
  
               if (pco%csvout == "y") then
-          write (3213,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
+          write (3213,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
               mallo(imallo)%trn(itrn)%ob_num, (mallo(imallo)%src(isrc)%num, mallo(imallo)%src(isrc)%mois_typ,   &
               mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%trn(itrn)%withdr_m(isrc),                       &
               isrc = 1, mallo(imallo)%src_obs)  
@@ -81,7 +81,7 @@
               isrc = 1, mallo(imallo)%src_obs) 
   
               if (pco%csvout == "y") then
-          write (3215,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
+          write (3215,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
               mallo(imallo)%trn(itrn)%ob_num, (mallo(imallo)%src(isrc)%num, mallo(imallo)%src(isrc)%mois_typ,   &
               mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%trn(itrn)%withdr_y(isrc),                       &
               isrc = 1, mallo(imallo)%src_obs)  
@@ -108,7 +108,7 @@
               isrc = 1, mallo(imallo)%src_obs) 
 
         if (pco%csvout == "y") then
-        write (3217,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
+        write (3217,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%trn(itrn)%ob_typ, &
               mallo(imallo)%trn(itrn)%ob_num, (mallo(imallo)%src(isrc)%num, mallo(imallo)%src(isrc)%mois_typ,   &
               mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%trn(itrn)%withdr_a(isrc),                       &
               isrc = 1, mallo(imallo)%src_obs)  

--- a/src/manure_source_output.f90
+++ b/src/manure_source_output.f90
@@ -21,7 +21,7 @@
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_d  
 
            if (pco%csvout == "y") then
-          write (3201,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
+          write (3201,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_d  
 
            end if
@@ -39,7 +39,7 @@
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_m
  
               if (pco%csvout == "y") then
-          write (3203,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
+          write (3203,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_m  
 
           end if
@@ -59,7 +59,7 @@
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_y
   
               if (pco%csvout == "y") then
-          write (3205,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
+          write (3205,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_y
           end if
         end if
@@ -78,7 +78,7 @@
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_a
 
         if (pco%csvout == "y") then
-        write (3207,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
+        write (3207,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, mallo(imallo)%src(isrc)%num,   &
               mallo(imallo)%src(isrc)%mois_typ, mallo(imallo)%src(isrc)%manure_typ, mallo(imallo)%src(isrc)%bal_a
         end if
        end if

--- a/src/output_landscape_init.f90
+++ b/src/output_landscape_init.f90
@@ -27,8 +27,8 @@
             if (pco%csvout == "y") then
               call open_output_file(2004, "hru_wb_day.csv", 1500)
               write (2004,*)  bsn%name, prog
-              write (2004,'(*(G0.3,:,","))') wb_hdr  !! hru
-              write (2004,'(*(G0.3,:,","))') wb_hdr_units
+              write (2004,'(*(G0.6,:,","))') wb_hdr  !! hru
+              write (2004,'(*(G0.6,:,","))') wb_hdr_units
               write (9000,*) "HRU                       hru_wb_day.csv"
               !write (9000,*) "HRU                 waterbal_day_hru.csv"              
             end if 
@@ -44,8 +44,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2005, "hru_wb_mon.csv", 1500)
             write (2005,*)  bsn%name, prog
-            write (2005,'(*(G0.3,:,","))') wb_hdr   !! hru
-            write (2005,'(*(G0.3,:,","))') wb_hdr_units
+            write (2005,'(*(G0.6,:,","))') wb_hdr   !! hru
+            write (2005,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "HRU                       hru_wb_mon.csv"
             !write (9000,*) "HRU                 waterbal_mon_hru.csv"
           end if
@@ -60,8 +60,8 @@
             if (pco%csvout == "y") then
               call open_output_file(2006, "hru_wb_yr.csv", 1500)
               write (2006,*)  bsn%name, prog
-              write (2006,'(*(G0.3,:,","))') wb_hdr  !! hru
-              write (2006,'(*(G0.3,:,","))') wb_hdr_units
+              write (2006,'(*(G0.6,:,","))') wb_hdr  !! hru
+              write (2006,'(*(G0.6,:,","))') wb_hdr_units
               write (9000,*) "HRU                       hru_wb_yr.csv"
               !write (9000,*) "HRU                 waterbal_yr_hru.csv"
             end if 
@@ -76,8 +76,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2007, "hru_wb_aa.csv", 1500)
             write (2007,*)  bsn%name, prog
-            write (2007,'(*(G0.3,:,","))') wb_hdr   !! hru
-            write (2007,'(*(G0.3,:,","))') wb_hdr_units
+            write (2007,'(*(G0.6,:,","))') wb_hdr   !! hru
+            write (2007,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "HRU                       hru_wb_aa.csv"
           end if
         end if 
@@ -92,8 +92,8 @@
             if (pco%csvout == "y") then
               call open_output_file(2024, "hru_nb_day.csv", 1500)
               write (2024,*)  bsn%name, prog
-              write (2024,'(*(G0.3,:,","))') nb_hdr
-              write (2024,'(*(G0.3,:,","))') nb_hdr_units
+              write (2024,'(*(G0.6,:,","))') nb_hdr
+              write (2024,'(*(G0.6,:,","))') nb_hdr_units
               write (9000,*) "HRU                       hru_nb_day.csv"
             end if
         endif
@@ -108,8 +108,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3334, "hru_ncycle_day.csv", 1500)
               write (3334,*)  bsn%name, prog
-              write (3334,'(*(G0.3,:,","))') nb_hdr1
-              write (3334,'(*(G0.3,:,","))') nb_hdr_units1
+              write (3334,'(*(G0.6,:,","))') nb_hdr1
+              write (3334,'(*(G0.6,:,","))') nb_hdr_units1
               write (9000,*) "HRU                       hru_ncycle_day.csv"
             end if
         endif
@@ -123,8 +123,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3336, "hru_ncycle_mon.csv", 1500)
               write (3336,*)  bsn%name, prog
-              write (3336,'(*(G0.3,:,","))') nb_hdr1
-              write (3336,'(*(G0.3,:,","))') nb_hdr_units1
+              write (3336,'(*(G0.6,:,","))') nb_hdr1
+              write (3336,'(*(G0.6,:,","))') nb_hdr_units1
               write (9000,*) "HRU                       hru_ncycle_mon.csv"
             end if
         endif
@@ -138,8 +138,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3338, "hru_ncycle_yr.csv", 1500)
               write (3338,*)  bsn%name, prog
-              write (3338,'(*(G0.3,:,","))') nb_hdr1
-              write (3338,'(*(G0.3,:,","))') nb_hdr_units1
+              write (3338,'(*(G0.6,:,","))') nb_hdr1
+              write (3338,'(*(G0.6,:,","))') nb_hdr_units1
               write (9000,*) "HRU                       hru_ncycle_yr.csv"
             end if
         endif
@@ -153,8 +153,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3340, "hru_ncycle_aa.csv", 1500)
               write (3340,*)  bsn%name, prog
-              write (3340,'(*(G0.3,:,","))') nb_hdr1
-              write (3340,'(*(G0.3,:,","))') nb_hdr_units1
+              write (3340,'(*(G0.6,:,","))') nb_hdr1
+              write (3340,'(*(G0.6,:,","))') nb_hdr_units1
               write (9000,*) "HRU                       hru_ncycle_aa.csv"
             end if
         endif
@@ -169,8 +169,8 @@
         if (pco%csvout == "y") then
           call open_output_file(2025, "hru_nb_mon.csv", 1500)
           write (2025,*) bsn%name, prog
-          write (2025,'(*(G0.3,:,","))') nb_hdr
-          write (2025,'(*(G0.3,:,","))') nb_hdr_units
+          write (2025,'(*(G0.6,:,","))') nb_hdr
+          write (2025,'(*(G0.6,:,","))') nb_hdr_units
           write (9000,*) "HRU                       hru_nb_mon.csv"
         end if
        end if
@@ -184,8 +184,8 @@
             if (pco%csvout == "y") then
               call open_output_file(2026, "hru_nb_yr.csv", 1500)
               write (2026,*) bsn%name, prog
-              write (2026,'(*(G0.3,:,","))') nb_hdr
-              write (2026,'(*(G0.3,:,","))') nb_hdr_units
+              write (2026,'(*(G0.6,:,","))') nb_hdr
+              write (2026,'(*(G0.6,:,","))') nb_hdr_units
               write (9000,*) "HRU                       hru_nb_yr.csv" 
             end if
         endif
@@ -199,8 +199,8 @@
         if (pco%csvout == "y") then
           call open_output_file(2027, "hru_nb_aa.csv", 1500)
           write (2027,*) bsn%name, prog
-          write (2027,'(*(G0.3,:,","))') nb_hdr
-          write (2027,'(*(G0.3,:,","))') nb_hdr_units
+          write (2027,'(*(G0.6,:,","))') nb_hdr
+          write (2027,'(*(G0.6,:,","))') nb_hdr_units
           write (9000,*) "HRU                       hru_nb_aa.csv"
         end if
        end if
@@ -215,8 +215,8 @@
              if (pco%csvout == "y") then
               call open_output_file(4524, "hru_soilcarb_day.csv", 1500)
               write (4524,*)  bsn%name, prog
-              write (4524,'(*(G0.3,:,","))') soilcarb_hdr
-              write (4524,'(*(G0.3,:,","))') soilcarb_hdr_units
+              write (4524,'(*(G0.6,:,","))') soilcarb_hdr
+              write (4524,'(*(G0.6,:,","))') soilcarb_hdr_units
               write (9000,*) "HRU                       hru_soilcarb_day.csv"
             end if
         endif
@@ -230,8 +230,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4525, "hru_soilcarb_mon.csv", 1500)
               write (4525,*)  bsn%name, prog
-              write (4525,'(*(G0.3,:,","))') soilcarb_hdr
-              write (4525,'(*(G0.3,:,","))') soilcarb_hdr_units
+              write (4525,'(*(G0.6,:,","))') soilcarb_hdr
+              write (4525,'(*(G0.6,:,","))') soilcarb_hdr_units
               write (9000,*) "HRU                       hru_soilcarb_mon.csv"
             end if
         endif
@@ -245,8 +245,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4526, "hru_soilcarb_yr.csv", 1500)
               write (4526,*)  bsn%name, prog
-              write (4526,'(*(G0.3,:,","))') soilcarb_hdr
-              write (4526,'(*(G0.3,:,","))') soilcarb_hdr_units
+              write (4526,'(*(G0.6,:,","))') soilcarb_hdr
+              write (4526,'(*(G0.6,:,","))') soilcarb_hdr_units
               write (9000,*) "HRU                       hru_soilcarb_yr.csv"
             end if
         endif
@@ -260,8 +260,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4527, "hru_soilcarb_aa.csv", 1500)
               write (4527,*)  bsn%name, prog
-              write (4527,'(*(G0.3,:,","))') soilcarb_hdr
-              write (4527,'(*(G0.3,:,","))') soilcarb_hdr_units
+              write (4527,'(*(G0.6,:,","))') soilcarb_hdr
+              write (4527,'(*(G0.6,:,","))') soilcarb_hdr_units
               write (9000,*) "HRU                       hru_soilcarb_aa.csv"
             end if
         endif
@@ -278,8 +278,8 @@
              if (pco%csvout == "y") then
               call open_output_file(4534, "hru_rescarb_day.csv", 1500)
               write (4534,*)  bsn%name, prog
-              write (4534,'(*(G0.3,:,","))') rescarb_hdr
-              write (4534,'(*(G0.3,:,","))') rescarb_hdr_units
+              write (4534,'(*(G0.6,:,","))') rescarb_hdr
+              write (4534,'(*(G0.6,:,","))') rescarb_hdr_units
               write (9000,*) "HRU                       hru_rescarb_day.csv"
             end if
         endif
@@ -293,8 +293,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4535, "hru_rescarb_mon.csv", 1500)
               write (4535,*)  bsn%name, prog
-              write (4535,'(*(G0.3,:,","))') rescarb_hdr
-              write (4535,'(*(G0.3,:,","))') rescarb_hdr_units
+              write (4535,'(*(G0.6,:,","))') rescarb_hdr
+              write (4535,'(*(G0.6,:,","))') rescarb_hdr_units
               write (9000,*) "HRU                       hru_rescarb_mon.csv"
             end if
         endif
@@ -308,8 +308,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4536, "hru_rescarb_yr.csv", 1500)
               write (4536,*)  bsn%name, prog
-              write (4536,'(*(G0.3,:,","))') rescarb_hdr
-              write (4536,'(*(G0.3,:,","))') rescarb_hdr_units
+              write (4536,'(*(G0.6,:,","))') rescarb_hdr
+              write (4536,'(*(G0.6,:,","))') rescarb_hdr_units
               write (9000,*) "HRU                       hru_rescarb_yr.csv"
             end if
         endif
@@ -323,8 +323,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4537, "hru_rescarb_aa.csv", 1500)
               write (4537,*)  bsn%name, prog
-              write (4537,'(*(G0.3,:,","))') rescarb_hdr
-              write (4537,'(*(G0.3,:,","))') rescarb_hdr_units
+              write (4537,'(*(G0.6,:,","))') rescarb_hdr
+              write (4537,'(*(G0.6,:,","))') rescarb_hdr_units
               write (9000,*) "HRU                       hru_rescarb_aa.csv"
             end if
         endif
@@ -341,8 +341,8 @@
              if (pco%csvout == "y") then
               call open_output_file(4544, "hru_plcarb_day.csv", 1500)
               write (4544,*)  bsn%name, prog
-              write (4544,'(*(G0.3,:,","))') plcarb_hdr
-              write (4544,'(*(G0.3,:,","))') plcarb_hdr_units
+              write (4544,'(*(G0.6,:,","))') plcarb_hdr
+              write (4544,'(*(G0.6,:,","))') plcarb_hdr_units
               write (9000,*) "HRU                       hru_plcarb_day.csv"
             end if
         endif
@@ -356,8 +356,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4545, "hru_plcarb_mon.csv", 1500)
               write (4545,*)  bsn%name, prog
-              write (4545,'(*(G0.3,:,","))') plcarb_hdr
-              write (4545,'(*(G0.3,:,","))') plcarb_hdr_units
+              write (4545,'(*(G0.6,:,","))') plcarb_hdr
+              write (4545,'(*(G0.6,:,","))') plcarb_hdr_units
               write (9000,*) "HRU                       hru_plcarb_mon.csv"
             end if
         endif
@@ -371,8 +371,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4546, "hru_plcarb_yr.csv", 1500)
               write (4546,*)  bsn%name, prog
-              write (4546,'(*(G0.3,:,","))') plcarb_hdr
-              write (4546,'(*(G0.3,:,","))') plcarb_hdr_units
+              write (4546,'(*(G0.6,:,","))') plcarb_hdr
+              write (4546,'(*(G0.6,:,","))') plcarb_hdr_units
               write (9000,*) "HRU                       hru_plcarb_yr.csv"
             end if
         endif
@@ -386,8 +386,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4547, "hru_plcarb_aa.csv", 1500)
               write (4547,*)  bsn%name, prog
-              write (4547,'(*(G0.3,:,","))') plcarb_hdr
-              write (4547,'(*(G0.3,:,","))') plcarb_hdr_units
+              write (4547,'(*(G0.6,:,","))') plcarb_hdr
+              write (4547,'(*(G0.6,:,","))') plcarb_hdr_units
               write (9000,*) "HRU                       hru_plcarb_aa.csv"
             end if
         endif
@@ -404,9 +404,9 @@
              if (pco%csvout == "y") then
               call open_output_file(4554, "hru_scf_day.csv", 1500)
               write (4554,*)  bsn%name, prog
-              write (4554,'(*(G0.3,:,","))') hscf_hdr
-              write (4554,'(*(G0.3,:,","))') hscf_hdr_units
-              write (9000,*) "HRU                       hru_plcarb_day.csv"
+              write (4554,'(*(G0.6,:,","))') hscf_hdr
+              write (4554,'(*(G0.6,:,","))') hscf_hdr_units
+              write (9000,*) "HRU                       hru_scf_day.csv"
             end if
         endif
         
@@ -419,8 +419,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4555, "hru_scf_mon.csv", 1500)
               write (4555,*)  bsn%name, prog
-              write (4555,'(*(G0.3,:,","))') hscf_hdr
-              write (4555,'(*(G0.3,:,","))') hscf_hdr_units
+              write (4555,'(*(G0.6,:,","))') hscf_hdr
+              write (4555,'(*(G0.6,:,","))') hscf_hdr_units
               write (9000,*) "HRU                       hru_scf_mon.csv"
             end if
         endif
@@ -434,8 +434,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4556, "hru_scf_yr.csv", 1500)
               write (4556,*)  bsn%name, prog
-              write (4556,'(*(G0.3,:,","))') hscf_hdr
-              write (4556,'(*(G0.3,:,","))') hscf_hdr_units
+              write (4556,'(*(G0.6,:,","))') hscf_hdr
+              write (4556,'(*(G0.6,:,","))') hscf_hdr_units
               write (9000,*) "HRU                       hru_scf_yr.csv"
             end if
         endif
@@ -449,8 +449,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4557, "hru_scf_aa.csv", 1500)
               write (4557,*)  bsn%name, prog
-              write (4557,'(*(G0.3,:,","))') hscf_hdr
-              write (4557,'(*(G0.3,:,","))') hscf_hdr_units
+              write (4557,'(*(G0.6,:,","))') hscf_hdr
+              write (4557,'(*(G0.6,:,","))') hscf_hdr_units
               write (9000,*) "HRU                       hru_scf_aa.csv"
             end if
         endif
@@ -489,8 +489,8 @@
           if (pco%csvout == "y") then
             call open_output_file(4563, "hru_plc_stat.csv", 1500)
             write (4563,*)  bsn%name, prog
-            write (4563,'(*(G0.3,:,","))') plc_hdr
-            write (4563,'(*(G0.3,:,","))') plc_hdr_units
+            write (4563,'(*(G0.6,:,","))') plc_hdr
+            write (4563,'(*(G0.6,:,","))') plc_hdr_units
             write (9000,*) "HRU                       hru_plc_stat.csv"
           end if
     
@@ -503,8 +503,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4564, "hru_rsdc_stat.csv", 1500)
               write (4564,*)  bsn%name, prog
-              write (4564,'(*(G0.3,:,","))') rsdc_hdr
-              write (4564,'(*(G0.3,:,","))') rsdc_hdr_units
+              write (4564,'(*(G0.6,:,","))') rsdc_hdr
+              write (4564,'(*(G0.6,:,","))') rsdc_hdr_units
               write (9000,*) "HRU                       hru_rsdc_stat.csv"
             end if
           
@@ -516,8 +516,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4565, "hru_soilc_stat.csv", 1500)
               write (4565,*)  bsn%name, prog
-              write (4565,'(*(G0.3,:,","))') soilc_hdr
-              write (4565,'(*(G0.3,:,","))') soilc_hdr_units
+              write (4565,'(*(G0.6,:,","))') soilc_hdr
+              write (4565,'(*(G0.6,:,","))') soilc_hdr_units
               write (9000,*) "HRU                       hru_soilc_stat.csv"
             end if
 
@@ -529,8 +529,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4568, "hru_cflux_stat.csv", 1500)
               write (4568,*)  bsn%name, prog
-              write (4568,'(*(G0.3,:,","))') soil_org_flux_hdr
-              write (4568,'(*(G0.3,:,","))') soil_org_flux_hdr_units
+              write (4568,'(*(G0.6,:,","))') soil_org_flux_hdr
+              write (4568,'(*(G0.6,:,","))') soil_org_flux_hdr_units
               write (9000,*) "HRU                       hru_cflux_stat.csv"
             end if
           
@@ -542,8 +542,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4571, "hru_soilcarb_mb_stat.csv", 1500)
               write (4571,*)  bsn%name, prog
-              write (4571,'(*(G0.3,:,","))') soil_mb_hdr
-              write (4571,'(*(G0.3,:,","))') soil_mb_units
+              write (4571,'(*(G0.6,:,","))') soil_mb_hdr
+              write (4571,'(*(G0.6,:,","))') soil_mb_units
               write (9000,*) "HRU                       hru_soilcarb_mb_stat.csv"
             end if
 
@@ -555,8 +555,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4573, "hru_cpool_stat.csv", 1500)
               write (4573,*)  bsn%name, prog
-              write (4573,'(*(G0.3,:,","))') cpool_hdr
-              write (4573,'(*(G0.3,:,","))') cpool_units
+              write (4573,'(*(G0.6,:,","))') cpool_hdr
+              write (4573,'(*(G0.6,:,","))') cpool_units
               write (9000,*) "HRU                       hru_cpool_stat.csv"
             end if
 
@@ -568,8 +568,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4583, "hru_n_p_pool_stat.csv", 1500)
               write (4583,*)  bsn%name, prog
-              write (4583,'(*(G0.3,:,","))') n_p_pool_hdr
-              write (4583,'(*(G0.3,:,","))') n_p_pool_units
+              write (4583,'(*(G0.6,:,","))') n_p_pool_hdr
+              write (4583,'(*(G0.6,:,","))') n_p_pool_units
               write (9000,*) "HRU                       hru_n_p_pool_stat.csv"
             end if
 
@@ -581,8 +581,8 @@
             if (pco%csvout == "y") then
               call open_output_file(4581, "hru_org_trans_vars.csv", 1500)
               write (4581,*)  bsn%name, prog
-              write (4581,'(*(G0.3,:,","))') org_trans_hdr
-              write (4581,'(*(G0.3,:,","))') org_trans_units
+              write (4581,'(*(G0.6,:,","))') org_trans_hdr
+              write (4581,'(*(G0.6,:,","))') org_trans_units
               write (9000,*) "HRU                       hru_org_trans_vars.csv"
             end if
 
@@ -599,7 +599,7 @@
             if (pco%csvout == "y") then
               call open_output_file(4575, "hru_carbvars.csv", 1500)
               write (4575,*)  bsn%name, prog
-              write (4575,'(*(G0.3,:,","))') carbvars_hdr
+              write (4575,'(*(G0.6,:,","))') carbvars_hdr
               write (9000,*) "HRU                       hru_carbvars.csv"
             end if
           endif
@@ -615,7 +615,7 @@
             if (pco%csvout == "y") then
               call open_output_file(4577, "hru_org_allo_vars.csv", 1500)
               write (4577,*)  bsn%name, prog
-              write (4577,'(*(G0.3,:,","))') org_allow_hdr
+              write (4577,'(*(G0.6,:,","))') org_allow_hdr
               write (9000,*) "HRU                       hru_org_allo_vars.csv"
             end if
           endif
@@ -631,7 +631,7 @@
             if (pco%csvout == "y") then
               call open_output_file(4579, "hru_org_ratio_vars.csv", 1500)
               write (4579,*)  bsn%name, prog
-              write (4579,'(*(G0.3,:,","))') org_ratio_hdr
+              write (4579,'(*(G0.6,:,","))') org_ratio_hdr
               write (9000,*) "HRU                       hru_org_ratio_vars.csv"
             end if
           endif
@@ -647,7 +647,7 @@
             if (pco%csvout == "y") then
               call open_output_file(4585, "hru_endsim_soil_prop.csv", 1500)
               write (4585,*)  bsn%name, prog
-              write (4585,'(*(G0.3,:,","))') endsim_soil_prop_hdr
+              write (4585,'(*(G0.6,:,","))') endsim_soil_prop_hdr
               write (9000,*) "HRU                       hru_endsim_soil_prop.csv"
             end if
           endif
@@ -663,7 +663,7 @@
             if (pco%csvout == "y") then
               call open_output_file(4587, "hru_begsim_soil_prop.csv", 1500)
               write (4587,*)  bsn%name, prog
-              write (4587,'(*(G0.3,:,","))') endsim_soil_prop_hdr ! begsim can use the same header as endsim 
+              write (4587,'(*(G0.6,:,","))') endsim_soil_prop_hdr ! begsim can use the same header as endsim 
               write (9000,*) "HRU                       hru_begsim_soil_prop.csv"
             end if
             ! Write out begining adjusted soil properties if any value of cb_hru is not "n"
@@ -697,8 +697,8 @@
             if (pco%csvout == "y") then
               call open_output_file(2034, "hru_ls_day.csv", 1500)
               write (2034,*) bsn%name, prog
-              write (2034,'(*(G0.3,:,","))') ls_hdr    !! hru
-              write (2034,'(*(G0.3,:,","))') ls_hdr_units
+              write (2034,'(*(G0.6,:,","))') ls_hdr    !! hru
+              write (2034,'(*(G0.6,:,","))') ls_hdr_units
               write (9000,*) "HRU                       hru_ls_day.csv"
             end if 
         endif
@@ -714,8 +714,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3342, "hru_nut_carb_gl_day.csv", 1500)
               write (3342,*) bsn%name, prog
-              write (3342,'(*(G0.3,:,","))') ls_hdr1    !! hru
-              write (3342,'(*(G0.3,:,","))') ls_hdr_units1
+              write (3342,'(*(G0.6,:,","))') ls_hdr1    !! hru
+              write (3342,'(*(G0.6,:,","))') ls_hdr_units1
               write (9000,*) "HRU                       hru_nut_carb_gl_day.csv"
             end if 
         endif
@@ -729,8 +729,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3344, "hru_nut_carb_gl_mon.csv", 1500)
               write (3344,*) bsn%name, prog
-              write (3344,'(*(G0.3,:,","))') ls_hdr1    !! hru
-              write (3344,'(*(G0.3,:,","))') ls_hdr_units1
+              write (3344,'(*(G0.6,:,","))') ls_hdr1    !! hru
+              write (3344,'(*(G0.6,:,","))') ls_hdr_units1
               write (9000,*) "HRU                       hru_nut_carb_gl_mon.csv"
             end if 
         endif
@@ -744,8 +744,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3346, "hru_nut_carb_gl_yr.csv", 1500)
               write (3346,*) bsn%name, prog
-              write (3346,'(*(G0.3,:,","))') ls_hdr1    !! hru
-              write (3346,'(*(G0.3,:,","))') ls_hdr_units1
+              write (3346,'(*(G0.6,:,","))') ls_hdr1    !! hru
+              write (3346,'(*(G0.6,:,","))') ls_hdr_units1
               write (9000,*) "HRU                       hru_nut_carb_gl_yr.csv"
             end if 
         endif
@@ -759,8 +759,8 @@
             if (pco%csvout == "y") then
               call open_output_file(3348, "hru_nut_carb_gl_aa.csv", 1500)
               write (3348,*) bsn%name, prog
-              write (3348,'(*(G0.3,:,","))') ls_hdr1    !! hru
-              write (3348,'(*(G0.3,:,","))') ls_hdr_units1
+              write (3348,'(*(G0.6,:,","))') ls_hdr1    !! hru
+              write (3348,'(*(G0.6,:,","))') ls_hdr_units1
               write (9000,*) "HRU                       hru_nut_carb_gl_aa.csv"
             end if 
         endif
@@ -775,8 +775,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2035, "hru_ls_mon.csv", 1500)
             write (2035,*) bsn%name, prog
-            write (2035,'(*(G0.3,:,","))') ls_hdr  !! hru
-            write (2035,'(*(G0.3,:,","))') ls_hdr_units
+            write (2035,'(*(G0.6,:,","))') ls_hdr  !! hru
+            write (2035,'(*(G0.6,:,","))') ls_hdr_units
             write (9000,*) "HRU                       hru_ls_mon.csv"
           end if
        endif
@@ -790,8 +790,8 @@
             if (pco%csvout == "y") then
               call open_output_file(2036, "hru_ls_yr.csv", 1500)
               write (2036,*) bsn%name, prog
-              write (2036,'(*(G0.3,:,","))') ls_hdr    !! hru
-              write (2036,'(*(G0.3,:,","))') ls_hdr_units
+              write (2036,'(*(G0.6,:,","))') ls_hdr    !! hru
+              write (2036,'(*(G0.6,:,","))') ls_hdr_units
               write (9000,*) "HRU                       hru_ls_yr.csv"
             end if 
         endif
@@ -805,8 +805,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2037, "hru_ls_aa.csv", 1500)
             write (2037,*) bsn%name, prog
-            write (2037,'(*(G0.3,:,","))') ls_hdr  !! hru
-            write (2037,'(*(G0.3,:,","))') ls_hdr_units
+            write (2037,'(*(G0.6,:,","))') ls_hdr  !! hru
+            write (2037,'(*(G0.6,:,","))') ls_hdr_units
             write (9000,*) "HRU                       hru_ls_aa.csv"
           end if 
        end if
@@ -821,8 +821,8 @@
             if (pco%csvout == "y") then 
               call open_output_file(2044, "hru_pw_day.csv", 1500)
               write (2044,*) bsn%name, prog
-              write (2044,'(*(G0.3,:,","))') pw_hdr  !! hru
-              write (2044,'(*(G0.3,:,","))') pw_hdr_units
+              write (2044,'(*(G0.6,:,","))') pw_hdr  !! hru
+              write (2044,'(*(G0.6,:,","))') pw_hdr_units
               write (9000,*) "HRU                       hru_pw_day.csv"
             end if 
         endif
@@ -836,8 +836,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2045, "hru_pw_mon.csv", 1500)
             write (2045,*) bsn%name, prog
-            write (2045,'(*(G0.3,:,","))') pw_hdr  !! hru
-            write (2045,'(*(G0.3,:,","))') pw_hdr_units
+            write (2045,'(*(G0.6,:,","))') pw_hdr  !! hru
+            write (2045,'(*(G0.6,:,","))') pw_hdr_units
             write (9000,*) "HRU                       hru_pw_mon.csv"
           end if 
       endif
@@ -851,8 +851,8 @@
             if (pco%csvout == "y") then 
               call open_output_file(2046, "hru_pw_yr.csv", 1500)
               write (2046,*) bsn%name, prog
-              write (2046,'(*(G0.3,:,","))') pw_hdr  !! hru
-              write (2046,'(*(G0.3,:,","))') pw_hdr_units
+              write (2046,'(*(G0.6,:,","))') pw_hdr  !! hru
+              write (2046,'(*(G0.6,:,","))') pw_hdr_units
               write (9000,*) "HRU                       hru_pw_yr.csv"
             end if 
         endif
@@ -866,8 +866,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2047, "hru_pw_aa.csv", 1500)
             write (2047,*) bsn%name, prog
-            write (2047,'(*(G0.3,:,","))') pw_hdr  !! hru
-            write (2047,'(*(G0.3,:,","))') pw_hdr_units
+            write (2047,'(*(G0.6,:,","))') pw_hdr  !! hru
+            write (2047,'(*(G0.6,:,","))') pw_hdr_units
             write (9000,*) "HRU                       hru_pw_aa.csv"
           end if 
        endif
@@ -885,8 +885,8 @@
             if (pco%csvout == "y") then 
               call open_output_file(2304, "hru-lte_wb_day.csv", 1500)
               write (2304,*) bsn%name, prog
-              write (2304,'(*(G0.3,:,","))') wb_hdr  !! swat-deg
-              write (2304,'(*(G0.3,:,","))') wb_hdr_units
+              write (2304,'(*(G0.6,:,","))') wb_hdr  !! swat-deg
+              write (2304,'(*(G0.6,:,","))') wb_hdr_units
               write (9000,*) "SWAT-DEG                  hru-lte_wb_day.csv"
             end if 
         endif
@@ -901,8 +901,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2305, "hru-lte_wb_mon.csv", 1500)
             write (2305,*) bsn%name, prog
-            write (2305,'(*(G0.3,:,","))') wb_hdr   !! swat deg
-            write (2305,'(*(G0.3,:,","))') wb_hdr_units
+            write (2305,'(*(G0.6,:,","))') wb_hdr   !! swat deg
+            write (2305,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "SWAT-DEG                  hru-lte_wb_mon.csv"
           end if
       end if
@@ -918,8 +918,8 @@
             if (pco%csvout == "y") then 
               call open_output_file(2306, "hru-lte_wb_yr.csv", 1500)
               write (2306,*) bsn%name, prog
-              write (2306,'(*(G0.3,:,","))') wb_hdr  !! swat-deg
-              write (2306,'(*(G0.3,:,","))') wb_hdr_units
+              write (2306,'(*(G0.6,:,","))') wb_hdr  !! swat-deg
+              write (2306,'(*(G0.6,:,","))') wb_hdr_units
               write (9000,*) "SWAT-DEG                  hru-lte_wb_yr.csv"
             end if 
         endif
@@ -935,8 +935,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2307, "hru-lte_wb_aa.csv", 1500)
             write (2307,*) bsn%name, prog
-            write (2307,'(*(G0.3,:,","))') wb_hdr   !! swat deg
-            write (2307,'(*(G0.3,:,","))') wb_hdr_units
+            write (2307,'(*(G0.6,:,","))') wb_hdr   !! swat deg
+            write (2307,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "SWAT-DEG                  hru-lte_wb_aa.csv"
           end if
       end if
@@ -963,8 +963,8 @@
             if (pco%csvout == "y") then 
               call open_output_file(2444, "hru-lte_ls_day.csv", 1500)
               write (2444,*) bsn%name, prog
-              write (2444,'(*(G0.3,:,","))') ls_hdr    !! swat-deg 
-              write (2444,'(*(G0.3,:,","))') ls_hdr_units
+              write (2444,'(*(G0.6,:,","))') ls_hdr    !! swat-deg 
+              write (2444,'(*(G0.6,:,","))') ls_hdr_units
               write (9000,*) "SWAT-DEG                  hru-lte_ls_day.csv"
             end if 
         endif
@@ -978,8 +978,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2445, "hru-lte_ls_mon.csv", 1500)
           write (2445,*) bsn%name, prog
-          write (2445,'(*(G0.3,:,","))') ls_hdr  !! swat-deg
-          write (2445,'(*(G0.3,:,","))') ls_hdr_units
+          write (2445,'(*(G0.6,:,","))') ls_hdr  !! swat-deg
+          write (2445,'(*(G0.6,:,","))') ls_hdr_units
           write (9000,*) "SWAT-DEG                  hru-lte_ls_mon.csv"
         end if
       end if
@@ -993,8 +993,8 @@
             if (pco%csvout == "y") then 
               call open_output_file(2446, "hru-lte_ls_yr.csv", 1500)
               write (2446,*) bsn%name, prog
-              write (2446,'(*(G0.3,:,","))') ls_hdr    !! swat-deg 
-              write (2446,'(*(G0.3,:,","))') ls_hdr_units
+              write (2446,'(*(G0.6,:,","))') ls_hdr    !! swat-deg 
+              write (2446,'(*(G0.6,:,","))') ls_hdr_units
               write (9000,*) "SWAT-DEG                  hru-lte_ls_yr.csv"
             end if 
         endif
@@ -1008,8 +1008,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2447, "hru-lte_ls_aa.csv", 1500)
           write (2447,*) bsn%name, prog
-          write (2447,'(*(G0.3,:,","))') ls_hdr  !! swat-deg
-          write (2447,'(*(G0.3,:,","))') ls_hdr_units
+          write (2447,'(*(G0.6,:,","))') ls_hdr  !! swat-deg
+          write (2447,'(*(G0.6,:,","))') ls_hdr_units
           write (9000,*) "SWAT-DEG                  hru-lte_ls_aa.csv"
         end if
       end if 
@@ -1025,8 +1025,8 @@
            if (pco%csvout == "y") then 
              call open_output_file(2464, "hru-lte_pw_day.csv", 1500)
              write (2464,*) bsn%name, prog
-             write (2464,'(*(G0.3,:,","))') pw_hdr  !! swat-deg
-             write (2464,'(*(G0.3,:,","))') pw_hdr_units
+             write (2464,'(*(G0.6,:,","))') pw_hdr  !! swat-deg
+             write (2464,'(*(G0.6,:,","))') pw_hdr_units
              write (9000,*) "SWAT-DEG                  hru-lte_pw_day.csv"
            end if
         endif
@@ -1040,8 +1040,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2465, "hru-lte_pw_mon.csv", 1500)
             write (2465,*) bsn%name, prog
-            write (2465,'(*(G0.3,:,","))') pw_hdr !! swat-deg
-            write (2465,'(*(G0.3,:,","))') pw_hdr_units
+            write (2465,'(*(G0.6,:,","))') pw_hdr !! swat-deg
+            write (2465,'(*(G0.6,:,","))') pw_hdr_units
             write (9000,*) "SWAT-DEG                  hru-lte_pw_mon.csv"
           end if
         end if
@@ -1055,8 +1055,8 @@
            if (pco%csvout == "y") then 
              call open_output_file(2466, "hru-lte_pw_yr.csv", 1500)
              write (2466,*) bsn%name, prog
-             write (2466,'(*(G0.3,:,","))') pw_hdr  !! swat-deg
-             write (2466,'(*(G0.3,:,","))') pw_hdr_units
+             write (2466,'(*(G0.6,:,","))') pw_hdr  !! swat-deg
+             write (2466,'(*(G0.6,:,","))') pw_hdr_units
              write (9000,*) "SWAT-DEG                  hru-lte_pw_yr.csv"
            end if
        endif
@@ -1070,8 +1070,8 @@
          if (pco%csvout == "y") then 
           call open_output_file(2467, "hru-lte_pw_aa.csv", 1500)
           write (2467,*) bsn%name, prog
-          write (2467,'(*(G0.3,:,","))') pw_hdr !! swat-deg
-          write (2467,'(*(G0.3,:,","))') pw_hdr_units
+          write (2467,'(*(G0.6,:,","))') pw_hdr !! swat-deg
+          write (2467,'(*(G0.6,:,","))') pw_hdr_units
           write (9000,*) "SWAT-DEG                  hru-lte_pw_aa.csv"
         end if 
       endif
@@ -1088,8 +1088,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2144, "lsunit_wb_day.csv", 1500)
             write (2144,*) bsn%name, prog
-            write (2144,'(*(G0.3,:,","))') wb_hdr  !! subbasin
-            write (2144,'(*(G0.3,:,","))') wb_hdr_units
+            write (2144,'(*(G0.6,:,","))') wb_hdr  !! subbasin
+            write (2144,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_wb_day.csv"
           end if 
         endif
@@ -1104,8 +1104,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2145, "lsunit_wb_mon.csv", 1500)
             write (2145,*) bsn%name, prog
-            write (2145,'(*(G0.3,:,","))') wb_hdr   !! subbasin
-            write (2145,'(*(G0.3,:,","))') wb_hdr_units
+            write (2145,'(*(G0.6,:,","))') wb_hdr   !! subbasin
+            write (2145,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_wb_mon.csv"
           end if
         end if 
@@ -1120,8 +1120,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2146, "lsunit_wb_yr.csv", 1500)
             write (2146,*) bsn%name, prog
-            write (2146,'(*(G0.3,:,","))') wb_hdr  !! subbasin
-            write (2146,'(*(G0.3,:,","))') wb_hdr_units
+            write (2146,'(*(G0.6,:,","))') wb_hdr  !! subbasin
+            write (2146,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_wb_yr.csv"
           end if 
         endif
@@ -1136,8 +1136,8 @@
           if (pco%csvout == "y") then
            call open_output_file(2147, "lsunit_wb_aa.csv", 1500)
            write (2147,*) bsn%name, prog
-           write (2147,'(*(G0.3,:,","))') wb_hdr   !! subbasin
-           write (2147,'(*(G0.3,:,","))') wb_hdr_units
+           write (2147,'(*(G0.6,:,","))') wb_hdr   !! subbasin
+           write (2147,'(*(G0.6,:,","))') wb_hdr_units
            write (9000,*) "ROUTING_UNIT              lsunit_wb_aa.csv"
           end if
        end if
@@ -1152,8 +1152,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2154, "lsunit_nb_day.csv", 1500)
             write (2154,*) bsn%name, prog
-            write (2154,'(*(G0.3,:,","))') nb_hdr
-            write (2154,'(*(G0.3,:,","))') nb_hdr_units
+            write (2154,'(*(G0.6,:,","))') nb_hdr
+            write (2154,'(*(G0.6,:,","))') nb_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_nb_day.csv"
           end if 
         endif
@@ -1167,8 +1167,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2155, "lsunit_nb_mon.csv", 1500)
             write (2155,*) bsn%name, prog
-            write (2155,'(*(G0.3,:,","))') nb_hdr
-            write (2155,'(*(G0.3,:,","))') nb_hdr_units
+            write (2155,'(*(G0.6,:,","))') nb_hdr
+            write (2155,'(*(G0.6,:,","))') nb_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_nb_mon.csv"
           end if
         end if
@@ -1182,8 +1182,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2156, "lsunit_nb_yr.csv", 1500)
             write (2156,*) bsn%name, prog
-            write (2156,'(*(G0.3,:,","))') nb_hdr
-            write (2156,'(*(G0.3,:,","))') nb_hdr_units
+            write (2156,'(*(G0.6,:,","))') nb_hdr
+            write (2156,'(*(G0.6,:,","))') nb_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_nb_yr.csv"
           end if 
         endif
@@ -1197,8 +1197,8 @@
           if (pco%csvout == "y") then
             call open_output_file(2157, "lsunit_nb_aa.csv", 1500)
             write (2157,*) bsn%name, prog
-            write (2157,'(*(G0.3,:,","))') nb_hdr
-            write (2157,'(*(G0.3,:,","))') nb_hdr_units
+            write (2157,'(*(G0.6,:,","))') nb_hdr
+            write (2157,'(*(G0.6,:,","))') nb_hdr_units
           write (9000,*) "ROUTING_UNIT              lsunit_nb_aa.csv"
           end if 
         end if 
@@ -1213,8 +1213,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2164, "lsunit_ls_day.csv", 1500)
             write (2164,*) bsn%name, prog
-            write (2164,'(*(G0.3,:,","))') ls_hdr    !! subbasin
-            write (2164,'(*(G0.3,:,","))') ls_hdr_units
+            write (2164,'(*(G0.6,:,","))') ls_hdr    !! subbasin
+            write (2164,'(*(G0.6,:,","))') ls_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_ls_day.csv"
           end if 
         endif
@@ -1228,8 +1228,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2165, "lsunit_ls_mon.csv", 1500)
           write (2165,*) bsn%name, prog
-          write (2165,'(*(G0.3,:,","))') ls_hdr  !! subbasin 
-          write (2165,'(*(G0.3,:,","))') ls_hdr_units
+          write (2165,'(*(G0.6,:,","))') ls_hdr  !! subbasin 
+          write (2165,'(*(G0.6,:,","))') ls_hdr_units
           write (9000,*) "ROUTING_UNIT              lsunit_ls_mon.csv"
         end if 
       end if 
@@ -1243,8 +1243,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2166, "lsunit_ls_yr.csv", 1500)
             write (2166,*) bsn%name, prog
-            write (2166,'(*(G0.3,:,","))') ls_hdr
-            write (2166,'(*(G0.3,:,","))') ls_hdr_units
+            write (2166,'(*(G0.6,:,","))') ls_hdr
+            write (2166,'(*(G0.6,:,","))') ls_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_ls_yr.csv"
           end if 
        endif
@@ -1258,8 +1258,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2167, "lsunit_ls_aa.csv", 1500)
           write (2167,*) bsn%name, prog
-          write (2167,'(*(G0.3,:,","))') ls_hdr
-          write (2167,'(*(G0.3,:,","))') ls_hdr_units
+          write (2167,'(*(G0.6,:,","))') ls_hdr
+          write (2167,'(*(G0.6,:,","))') ls_hdr_units
           write (9000,*) "ROUTING_UNIT              lsunit_ls_aa.csv"
         end if 
        end if
@@ -1274,8 +1274,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2174, "lsunit_pw_day.csv", 1500)
             write (2174,*) bsn%name, prog
-            write (2174,'(*(G0.3,:,","))') pw_hdr 
-            write (2174,'(*(G0.3,:,","))') pw_hdr_units
+            write (2174,'(*(G0.6,:,","))') pw_hdr 
+            write (2174,'(*(G0.6,:,","))') pw_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_pw_day.csv"
           end if 
         end if 
@@ -1290,8 +1290,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2175, "lsunit_pw_mon.csv", 1500)
           write (2175,*) bsn%name, prog
-          write (2175,'(*(G0.3,:,","))') pw_hdr
-          write (2175,'(*(G0.3,:,","))') pw_hdr_units
+          write (2175,'(*(G0.6,:,","))') pw_hdr
+          write (2175,'(*(G0.6,:,","))') pw_hdr_units
           write (9000,*) "ROUTING_UNIT              lsunit_pw_mon.csv"
         end if
        end if
@@ -1305,8 +1305,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2176, "lsunit_pw_yr.csv", 1500)
             write (2176,*) bsn%name, prog
-            write (2176, '(*(G0.3,:,","))')pw_hdr
-            write (2176,'(*(G0.3,:,","))') pw_hdr_units
+            write (2176, '(*(G0.6,:,","))')pw_hdr
+            write (2176,'(*(G0.6,:,","))') pw_hdr_units
             write (9000,*) "ROUTING_UNIT              lsunit_pw_yr.csv"
           end if 
         end if 
@@ -1320,8 +1320,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2177, "lsunit_pw_aa.csv", 1500)
           write (2177,*) bsn%name, prog
-          write (2177,'(*(G0.3,:,","))') pw_hdr
-          write (2177,'(*(G0.3,:,","))') pw_hdr_units
+          write (2177,'(*(G0.6,:,","))') pw_hdr
+          write (2177,'(*(G0.6,:,","))') pw_hdr_units
           write (9000,*) "ROUTING_UNIT              lsunit_pw_aa.csv"
         end if
      end if
@@ -1337,8 +1337,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2054, "basin_wb_day.csv", 1500)
             write (2054,*) bsn%name, prog
-            write (2054,'(*(G0.3,:,","))') wb_hdr !! bsn
-            write (2054,'(*(G0.3,:,","))') wb_hdr_units
+            write (2054,'(*(G0.6,:,","))') wb_hdr !! bsn
+            write (2054,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "BASIN                     basin_wb_day.csv"
           end if 
         endif
@@ -1352,8 +1352,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2055, "basin_wb_mon.csv", 1500)
           write (2055,*) bsn%name, prog
-          write (2055,'(*(G0.3,:,","))') wb_hdr !! bsn
-          write (2055,'(*(G0.3,:,","))') wb_hdr_units
+          write (2055,'(*(G0.6,:,","))') wb_hdr !! bsn
+          write (2055,'(*(G0.6,:,","))') wb_hdr_units
           write (9000,*) "BASIN                     basin_wb_mon.csv"
         end if
        end if 
@@ -1367,8 +1367,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2056, "basin_wb_yr.csv", 1500)
             write (2056,*) bsn%name, prog
-            write (2056,'(*(G0.3,:,","))') wb_hdr !! bsn
-            write (2056,'(*(G0.3,:,","))') wb_hdr_units
+            write (2056,'(*(G0.6,:,","))') wb_hdr !! bsn
+            write (2056,'(*(G0.6,:,","))') wb_hdr_units
             write (9000,*) "BASIN                     basin_wb_yr.csv"
           end if 
         endif
@@ -1382,8 +1382,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2057, "basin_wb_aa.csv", 1500)
           write (2057,*) bsn%name, prog
-          write (2057,'(*(G0.3,:,","))') wb_hdr !! bsn
-          write (2057,'(*(G0.3,:,","))') wb_hdr_units
+          write (2057,'(*(G0.6,:,","))') wb_hdr !! bsn
+          write (2057,'(*(G0.6,:,","))') wb_hdr_units
           write (9000,*) "BASIN                     basin_wb_aa.csv"
         end if
        end if 
@@ -1398,8 +1398,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2064, "basin_nb_day.csv", 1500)
             write (2064,*) bsn%name, prog
-            write (2064,'(*(G0.3,:,","))') nb_hdr
-            write (2064,'(*(G0.3,:,","))') nb_hdr_units
+            write (2064,'(*(G0.6,:,","))') nb_hdr
+            write (2064,'(*(G0.6,:,","))') nb_hdr_units
             write (9000,*) "BASIN                     basin_nb_day.csv"
           end if 
         endif
@@ -1413,8 +1413,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2065, "basin_nb_mon.csv", 1500)
           write (2065,*) bsn%name, prog
-          write (2065,'(*(G0.3,:,","))') nb_hdr
-          write (2065,'(*(G0.3,:,","))') nb_hdr_units
+          write (2065,'(*(G0.6,:,","))') nb_hdr
+          write (2065,'(*(G0.6,:,","))') nb_hdr_units
           write (9000,*) "BASIN                     basin_nb_mon.csv"
         end if
        end if 
@@ -1428,8 +1428,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2066, "basin_nb_yr.csv", 1500)
             write (2066,*) bsn%name, prog
-            write (2066,'(*(G0.3,:,","))') nb_hdr
-            write (2066,'(*(G0.3,:,","))') nb_hdr_units
+            write (2066,'(*(G0.6,:,","))') nb_hdr
+            write (2066,'(*(G0.6,:,","))') nb_hdr_units
             write (9000,*) "BASIN                     basin_nb_yr.csv"
           end if 
         endif
@@ -1443,8 +1443,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2067, "basin_nb_aa.csv", 1500)
           write (2067,*) bsn%name, prog
-          write (2067,'(*(G0.3,:,","))') nb_hdr
-          write (2067,'(*(G0.3,:,","))') nb_hdr_units
+          write (2067,'(*(G0.6,:,","))') nb_hdr
+          write (2067,'(*(G0.6,:,","))') nb_hdr_units
           write (9000,*) "BASIN                     basin_nb_aa.csv"
         end if
        end if 
@@ -1459,8 +1459,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2074, "basin_ls_day.csv", 1500)
             write (2074,*) bsn%name, prog
-            write (2074,'(*(G0.3,:,","))') ls_hdr    !! bsn
-            write (2074,'(*(G0.3,:,","))') ls_hdr_units
+            write (2074,'(*(G0.6,:,","))') ls_hdr    !! bsn
+            write (2074,'(*(G0.6,:,","))') ls_hdr_units
             write (9000,*) "BASIN                     basin_ls_day.csv"
           end if 
         endif
@@ -1474,8 +1474,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2075, "basin_ls_mon.csv", 1500)
           write (2075,*) bsn%name, prog
-          write (2075,'(*(G0.3,:,","))') ls_hdr     !! bsn
-          write (2075,'(*(G0.3,:,","))') ls_hdr_units
+          write (2075,'(*(G0.6,:,","))') ls_hdr     !! bsn
+          write (2075,'(*(G0.6,:,","))') ls_hdr_units
           write (9000,*) "BASIN                     basin_ls_mon.csv"
         end if
        end if
@@ -1489,8 +1489,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2076, "basin_ls_yr.csv", 1500)
             write (2076,*) bsn%name, prog
-            write (2076,'(*(G0.3,:,","))') ls_hdr    !! bsn
-            write (2076,'(*(G0.3,:,","))') ls_hdr_units
+            write (2076,'(*(G0.6,:,","))') ls_hdr    !! bsn
+            write (2076,'(*(G0.6,:,","))') ls_hdr_units
             write (9000,*) "BASIN                     basin_ls_yr.csv"
           end if 
         endif
@@ -1504,8 +1504,8 @@
         if (pco%csvout == "y") then 
           call open_output_file(2077, "basin_ls_aa.csv", 1500)
           write (2077,*) bsn%name, prog
-          write (2077,'(*(G0.3,:,","))') ls_hdr     !! bsn
-          write (2077,'(*(G0.3,:,","))') ls_hdr_units
+          write (2077,'(*(G0.6,:,","))') ls_hdr     !! bsn
+          write (2077,'(*(G0.6,:,","))') ls_hdr_units
           write (9000,*) "BASIN                     basin_ls_aa.csv"
         end if
        end if
@@ -1520,8 +1520,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2084, "basin_pw_day.csv", 1500)
             write (2084,*) bsn%name, prog
-            write (2084,'(*(G0.3,:,","))') pw_hdr  !! bsn
-            write (2084,'(*(G0.3,:,","))') pw_hdr_units
+            write (2084,'(*(G0.6,:,","))') pw_hdr  !! bsn
+            write (2084,'(*(G0.6,:,","))') pw_hdr_units
             write (9000,*) "BASIN                     basin_pw_day.csv"
           end if
         endif
@@ -1535,8 +1535,8 @@
        if (pco%csvout == "y") then 
           call open_output_file(2085, "basin_pw_mon.csv", 1500)
           write (2085,*) bsn%name, prog
-          write (2085,'(*(G0.3,:,","))') pw_hdr     !! bsn
-          write (2085,'(*(G0.3,:,","))') pw_hdr_units
+          write (2085,'(*(G0.6,:,","))') pw_hdr     !! bsn
+          write (2085,'(*(G0.6,:,","))') pw_hdr_units
           write (9000,*) "BASIN                     basin_pw_mon.csv"
        end if
       end if
@@ -1550,8 +1550,8 @@
           if (pco%csvout == "y") then 
             call open_output_file(2086, "basin_pw_yr.csv", 1500)
             write (2086,*) bsn%name, prog
-            write (2086,'(*(G0.3,:,","))') pw_hdr  !! bsn
-            write (2086,'(*(G0.3,:,","))') pw_hdr_units
+            write (2086,'(*(G0.6,:,","))') pw_hdr  !! bsn
+            write (2086,'(*(G0.6,:,","))') pw_hdr_units
             write (9000,*) "BASIN                     basin_pw_yr.csv"
           end if
         endif
@@ -1565,8 +1565,8 @@
        if (pco%csvout == "y") then 
           call open_output_file(2087, "basin_pw_aa.csv", 1500)
           write (2087,*) bsn%name, prog
-          write (2087,'(*(G0.3,:,","))') pw_hdr     !! bsn
-          write (2087,'(*(G0.3,:,","))') pw_hdr_units
+          write (2087,'(*(G0.6,:,","))') pw_hdr     !! bsn
+          write (2087,'(*(G0.6,:,","))') pw_hdr_units
           write (9000,*) "BASIN                     basin_pw_aa.csv"
        end if
        end if
@@ -1581,7 +1581,7 @@
         if (pco%csvout == "y") then
             call open_output_file(4011, "crop_yld_yr.csv")
             write (4011,*) bsn%name, prog
-            write (4011,'(*(G0.3,:,","))') "jday","mon","day","year","unit","plantnm","yield"
+            write (4011,'(*(G0.6,:,","))') "jday","mon","day","year","unit","plantnm","yield"
             write (9000,*) "CROP                      crop_yld_yr.csv"
         end if
       end if
@@ -1595,7 +1595,7 @@
         if (pco%csvout == "y") then
             call open_output_file(4009, "crop_yld_aa.csv")
             write (4009,*) bsn%name, prog
-            write (4009,'(*(G0.3,:,","))') "jday","mon","day","year","unit","plantnm","yield"
+            write (4009,'(*(G0.6,:,","))') "jday","mon","day","year","unit","plantnm","yield"
             write (9000,*) "CROP                      crop_yld_aa.csv"
         end if
       end if

--- a/src/recall_output.f90
+++ b/src/recall_output.f90
@@ -22,7 +22,7 @@
           if (pco%recall%d == "y") then
             write (4600,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_d(irec)
             if (pco%csvout == "y") then
-              write (4604,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_d(irec)
+              write (4604,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_d(irec)
             end if
           end if
         end if
@@ -33,7 +33,7 @@
           if (pco%recall%m == "y") then
             write (4601,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_m(irec)
             if (pco%csvout == "y") then
-              write (4605,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_m(irec)
+              write (4605,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_m(irec)
             endif
           end if
           rec_m(irec) = hz
@@ -45,7 +45,7 @@
           if (pco%recall%y == "y") then
             write (4602,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_y(irec)
             if (pco%csvout == "y") then
-              write (4606,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_y(irec) 
+              write (4606,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_y(irec) 
             end if
           end if
           !! zero yearly variables        
@@ -57,7 +57,7 @@
           rec_a(irec) = rec_a(irec) / time%yrs_prt
             write (4603,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, rec_a(irec)
             if (pco%csvout == "y") then 
-              write (4607,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, ob(iob)%name, ob(iob)%typ, rec_a(irec)  
+              write (4607,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, ob(iob)%name, ob(iob)%typ, rec_a(irec)  
             end if 
           end if
 

--- a/src/res_cs_output.f90
+++ b/src/res_cs_output.f90
@@ -55,7 +55,7 @@
                          (rescs_d(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                           rescs_d(j)%cs(1)%volm
         if (pco%csvout == "y") then
-          write (6041,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (6041,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (rescs_d(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                         (rescs_d(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                         (rescs_d(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -109,7 +109,7 @@
                            (rescs_m(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                             rescs_m(j)%cs(1)%volm
           if (pco%csvout == "y") then
-            write (6043,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (6043,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (rescs_m(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                           (rescs_m(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                           (rescs_m(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -179,7 +179,7 @@
                            (rescs_y(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                             rescs_y(j)%cs(1)%volm
           if (pco%csvout == "y") then
-            write (6045,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (6045,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (rescs_y(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                           (rescs_y(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                           (rescs_y(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -242,7 +242,7 @@
                          (rescs_a(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                           rescs_a(j)%cs(1)%volm
         if (pco%csvout == "y") then
-          write (6047,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (6047,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (rescs_a(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                         (rescs_a(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                         (rescs_a(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &

--- a/src/res_pesticide_output.f90
+++ b/src/res_pesticide_output.f90
@@ -33,7 +33,7 @@
              write (2816,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                 respst_d(j)%pest(ipest)   !! pesticide balance
              if (pco%csvout == "y") then
-               write (2820,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2820,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                     cs_db%pests(ipest), respst_d(j)%pest(ipest)
              end if
           end if
@@ -52,7 +52,7 @@
              write (2817,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                 respst_m(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2821,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2821,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                     cs_db%pests(ipest), respst_m(j)%pest(ipest)
                end if
            end if
@@ -71,7 +71,7 @@
              write (2818,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
                 respst_y(j)%pest(ipest)
                if (pco%csvout == "y") then
-                 write (2822,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2822,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                     cs_db%pests(ipest), respst_y(j)%pest(ipest)
                end if
            end if
@@ -85,7 +85,7 @@
            write (2819,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, cs_db%pests(ipest), &
             respst_a(j)%pest(ipest)
            if (pco%csvout == "y") then
-             write (2823,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+             write (2823,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                 cs_db%pests(ipest), respst_a(j)%pest(ipest)
            end if
            respst_a(j)%pest(ipest) = res_pestbz

--- a/src/res_salt_output.f90
+++ b/src/res_salt_output.f90
@@ -49,7 +49,7 @@
                          (ressalt_d(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                           ressalt_d(j)%salt(1)%volm
         if (pco%csvout == "y") then
-          write (5041,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (5041,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (ressalt_d(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                         (ressalt_d(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                         (ressalt_d(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -94,7 +94,7 @@
                            (ressalt_m(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             ressalt_m(j)%salt(1)%volm
           if (pco%csvout == "y") then
-            write (5043,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (5043,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (ressalt_m(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                           (ressalt_m(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                           (ressalt_m(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -152,7 +152,7 @@
                            (ressalt_y(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             ressalt_y(j)%salt(1)%volm
           if (pco%csvout == "y") then
-            write (5045,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (5045,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (ressalt_y(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                           (ressalt_y(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                           (ressalt_y(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -203,7 +203,7 @@
                          (ressalt_a(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                           ressalt_a(j)%salt(1)%volm
         if (pco%csvout == "y") then
-          write (5047,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (5047,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (ressalt_a(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                         (ressalt_a(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                         (ressalt_a(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &

--- a/src/reservoir_output.f90
+++ b/src/reservoir_output.f90
@@ -20,7 +20,7 @@
             write (2540,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, res_wat_d(j), res(j), &
                 res_in_d(j), res_out_d(j)
                if (pco%csvout == "y") then
-                 write (2544,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                 write (2544,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                     res_wat_d(j), res(j), res_in_d(j), res_out_d(j)
              end if
           end if 
@@ -43,7 +43,7 @@
             write (2541,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, res_wat_m(j), res(j), &
                 res_in_m(j), res_out_m(j)
               if (pco%csvout == "y") then
-                write (2545,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                write (2545,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                     res_wat_m(j), res(j), res_in_m(j), res_out_m(j)
               end if 
           end if
@@ -63,7 +63,7 @@
             write (2542,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, res_wat_y(j), res(j), &
                 res_in_y(j), res_out_y(j)
               if (pco%csvout == "y") then
-                write (2546,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                write (2546,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                     res_wat_y(j), res(j), res_in_y(j), res_out_y(j)
               end if
           end if
@@ -80,7 +80,7 @@
           write (2543,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, res_wat_a(j), res(j), &
             res_in_a(j), res_out_a(j)
           if (pco%csvout == "y") then
-            write (2547,'(*(G0.3,:","))')time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+            write (2547,'(*(G0.6,:","))')time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                 res_wat_a(j), res(j), res_in_a(j), res_out_a(j)
           end if 
           res_in_a(j) = resmz

--- a/src/ru_cs_output.f90
+++ b/src/ru_cs_output.f90
@@ -63,7 +63,7 @@
                          (ru_hru_csb_d(iru)%cs(ics)%rctn,ics=1,cs_db%num_cs), &
                          (ru_hru_csb_d(iru)%cs(ics)%sorb,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6071,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (6071,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                                                            (rucsb_d(iru)%hd(1)%cs(ics),ics=1,cs_db%num_cs), & !total out
                                        (rucsb_d(iru)%hd(2)%cs(ics),ics=1,cs_db%num_cs), & !percolation
                                        (rucsb_d(iru)%hd(3)%cs(ics),ics=1,cs_db%num_cs), & !surface runoff
@@ -139,7 +139,7 @@
                            (ru_hru_csb_m(iru)%cs(ics)%rctn,ics=1,cs_db%num_cs), &
                            (ru_hru_csb_m(iru)%cs(ics)%sorb,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6073,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (6073,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                          (rucsb_m(iru)%hd(1)%cs(ics),ics=1,cs_db%num_cs), & !total out
                                          (rucsb_m(iru)%hd(2)%cs(ics),ics=1,cs_db%num_cs), & !percolation
                                          (rucsb_m(iru)%hd(3)%cs(ics),ics=1,cs_db%num_cs), & !surface runoff
@@ -215,7 +215,7 @@
                            (ru_hru_csb_y(iru)%cs(ics)%rctn,ics=1,cs_db%num_cs), &
                            (ru_hru_csb_y(iru)%cs(ics)%sorb,ics=1,cs_db%num_cs)
           if (pco%csvout == "y") then
-            write (6075,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (6075,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                          (rucsb_y(iru)%hd(1)%cs(ics),ics=1,cs_db%num_cs), & !total out
                                          (rucsb_y(iru)%hd(2)%cs(ics),ics=1,cs_db%num_cs), & !percolation
                                          (rucsb_y(iru)%hd(3)%cs(ics),ics=1,cs_db%num_cs), & !surface runoff
@@ -290,7 +290,7 @@
                         (ru_hru_csb_a(iru)%cs(ics)%rctn,ics=1,cs_db%num_cs), &
                         (ru_hru_csb_a(iru)%cs(ics)%sorb,ics=1,cs_db%num_cs)
         if (pco%csvout == "y") then
-          write (6077,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (6077,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                         (rucsb_a(iru)%hd(1)%cs(ics),ics=1,cs_db%num_cs), & !total out
                                         (rucsb_a(iru)%hd(2)%cs(ics),ics=1,cs_db%num_cs), & !percolation
                                         (rucsb_a(iru)%hd(3)%cs(ics),ics=1,cs_db%num_cs), & !surface runoff

--- a/src/ru_output.f90
+++ b/src/ru_output.f90
@@ -23,7 +23,7 @@
           if (pco%ru%d == "y") then
             write (2600,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_d(iru)
             if (pco%csvout == "y") then
-              write (2604,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_d(iru)
+              write (2604,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_d(iru)
             end if
           end if
         end if
@@ -34,7 +34,7 @@
           if (pco%ru%m == "y") then
             write (2601,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_m(iru)
             if (pco%csvout == "y") then
-              write (2605,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_m(iru)
+              write (2605,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_m(iru)
             endif
           end if
           ru_m(iru) = hz
@@ -46,7 +46,7 @@
           if (pco%ru%y == "y") then
             write (2602,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_y(iru)
             if (pco%csvout == "y") then
-              write (2606,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_y(iru) 
+              write (2606,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_y(iru) 
             end if
           end if
           !! zero yearly variables        
@@ -58,7 +58,7 @@
           ru_a(iru) = ru_a(iru) / time%yrs_prt
             write (2603,*) time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_a(iru)
             if (pco%csvout == "y") then 
-              write (2607,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_a(iru)  
+              write (2607,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ob(iob)%name, ob(iob)%typ, ru_a(iru)  
             end if 
           end if
 

--- a/src/ru_salt_output.f90
+++ b/src/ru_salt_output.f90
@@ -63,7 +63,7 @@
                          (ru_hru_saltb_d(iru)%salt(isalt)%uptk,isalt=1,cs_db%num_salts), &
                           ru_hru_saltb_d(iru)%salt(1)%diss       
         if (pco%csvout == "y") then
-          write (5071,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (5071,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                                                             (rusaltb_d(iru)%hd(1)%salt(isalt),isalt=1,cs_db%num_salts), &
                                         (rusaltb_d(iru)%hd(2)%salt(isalt),isalt=1,cs_db%num_salts), &
                                         (rusaltb_d(iru)%hd(3)%salt(isalt),isalt=1,cs_db%num_salts), &
@@ -138,7 +138,7 @@
                            (ru_hru_saltb_m(iru)%salt(isalt)%uptk,isalt=1,cs_db%num_salts), &
                             ru_hru_saltb_m(iru)%salt(1)%diss
           if (pco%csvout == "y") then
-            write (5073,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (5073,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                           (rusaltb_m(iru)%hd(1)%salt(isalt),isalt=1,cs_db%num_salts), &
                                           (rusaltb_m(iru)%hd(2)%salt(isalt),isalt=1,cs_db%num_salts), &
                                           (rusaltb_m(iru)%hd(3)%salt(isalt),isalt=1,cs_db%num_salts), &
@@ -213,7 +213,7 @@
                            (ru_hru_saltb_y(iru)%salt(isalt)%uptk,isalt=1,cs_db%num_salts), &
                             ru_hru_saltb_y(iru)%salt(1)%diss
           if (pco%csvout == "y") then
-            write (5075,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+            write (5075,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                           (rusaltb_y(iru)%hd(1)%salt(isalt),isalt=1,cs_db%num_salts), &
                                           (rusaltb_y(iru)%hd(2)%salt(isalt),isalt=1,cs_db%num_salts), &
                                           (rusaltb_y(iru)%hd(3)%salt(isalt),isalt=1,cs_db%num_salts), &
@@ -286,7 +286,7 @@
                          (ru_hru_saltb_a(iru)%salt(isalt)%uptk,isalt=1,cs_db%num_salts), &
                           ru_hru_saltb_a(iru)%salt(1)%diss
         if (pco%csvout == "y") then
-          write (5077,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
+          write (5077,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, iru, ob(iob)%gis_id, & 
                                         (rusaltb_a(iru)%hd(1)%salt(isalt),isalt=1,cs_db%num_salts), &
                                         (rusaltb_a(iru)%hd(2)%salt(isalt),isalt=1,cs_db%num_salts), &
                                         (rusaltb_a(iru)%hd(3)%salt(isalt),isalt=1,cs_db%num_salts), &

--- a/src/sd_chanbud_output.f90
+++ b/src/sd_chanbud_output.f90
@@ -18,7 +18,7 @@
         if (pco%sd_chan%d == "y") then
           write (4808,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, ch_sed_bud(ichan)
            if (pco%csvout == "y") then
-             write (4812,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+             write (4812,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
              ch_sed_bud(ichan)
            end if
         end if
@@ -33,7 +33,7 @@
           if (pco%sd_chan%m == "y") then
           write (4809,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, ch_sed_bud_m(ichan)
           if (pco%csvout == "y") then
-            write (4813,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+            write (4813,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
               ch_sed_bud_m(ichan)
           end if
         end if
@@ -49,7 +49,7 @@
         if (pco%sd_chan%y == "y") then 
           write (4810,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, ch_sed_bud_y(ichan)
           if (pco%csvout == "y") then
-           write (4814,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+           write (4814,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
              ch_sed_bud_y(ichan)
           end if
         end if
@@ -64,7 +64,7 @@
         if (pco%sd_chan%a == "y") then
         write (4811,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, ch_sed_bud_a(ichan)
         if (pco%csvout == "y") then
-          write (4815,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+          write (4815,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
             ch_sed_bud_a(ichan)
         end if
        end if

--- a/src/sd_chanmorph_output.f90
+++ b/src/sd_chanmorph_output.f90
@@ -19,7 +19,7 @@
         if (pco%sd_chan%d == "y") then
           write (4800,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, chsd_d(ichan)
            if (pco%csvout == "y") then
-             write (4804,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+             write (4804,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
              chsd_d(ichan)
            end if
         end if
@@ -34,7 +34,7 @@
           if (pco%sd_chan%m == "y") then
           write (4801,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, chsd_m(ichan)
           if (pco%csvout == "y") then
-            write (4805,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+            write (4805,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
               chsd_m(ichan)
           end if
         end if
@@ -50,7 +50,7 @@
         if (pco%sd_chan%y == "y") then 
           write (4802,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, chsd_y(ichan)
           if (pco%csvout == "y") then
-           write (4806,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+           write (4806,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
              chsd_y(ichan)
           end if
         end if
@@ -64,7 +64,7 @@
         if (pco%sd_chan%a == "y") then
         write (4803,100) time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, chsd_a(ichan)
         if (pco%csvout == "y") then
-          write (4807,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
+          write (4807,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name, &
             chsd_a(ichan)
         end if
        end if

--- a/src/sd_channel_output.f90
+++ b/src/sd_channel_output.f90
@@ -34,7 +34,7 @@
             ch_wat_d(ichan)%area_ha, ch_wat_d(ichan)%precip, ch_wat_d(ichan)%evap, ch_wat_d(ichan)%seep,        &                
             ch_stor(ichan), ch_in_d(ichan), ch_out_d(ichan), wtemp
            if (pco%csvout == "y") then
-             write (2504,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,  &
+             write (2504,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,  &
                ch_wat_d(ichan)%area_ha, ch_wat_d(ichan)%precip, ch_wat_d(ichan)%evap, ch_wat_d(ichan)%seep,     &
                ch_stor(ichan), ch_in_d(ichan), ch_out_d(ichan), wtemp
            end if
@@ -60,7 +60,7 @@
             ch_stor(ichan), ch_in_m(ichan), ch_out_m(ichan), wtemp
 
           if (pco%csvout == "y") then
-            write (2505,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,   &
+            write (2505,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,   &
             ch_wat_m(ichan)%area_ha, ch_wat_m(ichan)%precip, ch_wat_m(ichan)%evap, ch_wat_m(ichan)%seep,   &
             ch_stor(ichan), ch_in_m(ichan), ch_out_m(ichan), wtemp
           end if
@@ -89,7 +89,7 @@
             ch_wat_y(ichan)%area_ha, ch_wat_y(ichan)%precip, ch_wat_y(ichan)%evap, ch_wat_y(ichan)%seep,    &
             ch_stor(ichan), ch_in_y(ichan), ch_out_y(ichan), wtemp
           if (pco%csvout == "y") then
-           write (2506,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,    &
+           write (2506,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,    &
             ch_wat_y(ichan)%area_ha, ch_wat_y(ichan)%precip, ch_wat_y(ichan)%evap, ch_wat_y(ichan)%seep,    &
             ch_stor(ichan), ch_in_y(ichan), ch_out_y(ichan), wtemp
           end if
@@ -109,7 +109,7 @@
           ch_wat_a(ichan)%area_ha, ch_wat_a(ichan)%precip, ch_wat_a(ichan)%evap, ch_wat_a(ichan)%seep,   &
           ch_stor(ichan), ch_in_a(ichan), ch_out_a(ichan), wtemp
         if (pco%csvout == "y") then
-          write (2507,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,   &
+          write (2507,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, ichan, ob(iob)%gis_id, ob(iob)%name,   &
           ch_wat_a(ichan)%area_ha, ch_wat_a(ichan)%precip, ch_wat_a(ichan)%evap, ch_wat_a(ichan)%seep,   &
           ch_stor(ichan), ch_in_a(ichan), ch_out_a(ichan), wtemp
         end if

--- a/src/wallo_allo_output.f90
+++ b/src/wallo_allo_output.f90
@@ -27,7 +27,7 @@
               wallod_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
 
            if (pco%csvout == "y") then
-          write (3114,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
+          write (3114,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,           &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                      &
               wallod_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
@@ -53,7 +53,7 @@
               wallom_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
  
               if (pco%csvout == "y") then
-          write (3115,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
+          write (3115,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,         &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                    &
               wallom_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
@@ -81,7 +81,7 @@
               walloy_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
   
               if (pco%csvout == "y") then
-          write (3116,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
+          write (3116,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,         &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                    &
               walloy_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
@@ -108,7 +108,7 @@
               walloa_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
 
         if (pco%csvout == "y") then
-        write (3117,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
+        write (3117,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,         &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                    &
               walloa_out(iwallo)%trn(itrn)%src(isrc), isrc = 1, wallo(iwallo)%trn(itrn)%src_num)

--- a/src/wallo_treat_output.f90
+++ b/src/wallo_treat_output.f90
@@ -18,7 +18,7 @@
           write (3110,*) time%day, time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omd(itrt)
 
           if (pco%csvout == "y") then
-          write (3114,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omd(itrt)
+          write (3114,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omd(itrt)
           end if
         end if
        
@@ -34,7 +34,7 @@
           write (3111,*) time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omm(itrt)
  
           if (pco%csvout == "y") then
-          write (3115,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omm(itrt)
+          write (3115,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omm(itrt)
           end if
         end if
 
@@ -51,7 +51,7 @@
           write (3112,*) time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omy(itrt)
   
               if (pco%csvout == "y") then
-          write (3116,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omy(itrt)
+          write (3116,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_omy(itrt)
           end if
         end if
 
@@ -68,7 +68,7 @@
         write (3113,*) time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_oma(itrt)
 
         if (pco%csvout == "y") then
-        write (3117,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_oma(itrt)
+        write (3117,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, itrt, om_treat_name(itrt), wal_tr_oma(itrt)
         end if
        end if
       end if

--- a/src/wallo_trn_output.f90
+++ b/src/wallo_trn_output.f90
@@ -27,7 +27,7 @@
               wal_omd(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
 
            if (pco%csvout == "y") then
-          write (3114,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
+          write (3114,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,           &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                      &
               wal_omd(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
@@ -53,7 +53,7 @@
               wal_omm(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
  
               if (pco%csvout == "y") then
-          write (3115,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
+          write (3115,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,         &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                    &
               wal_omm(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
@@ -81,7 +81,7 @@
               wal_omy(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
   
               if (pco%csvout == "y") then
-          write (3116,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
+          write (3116,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ, &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,         &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                    &
               wal_omy(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
@@ -108,7 +108,7 @@
               wal_oma(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)
 
         if (pco%csvout == "y") then
-        write (3117,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
+        write (3117,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, itrn, wallo(iwallo)%trn(itrn)%trn_typ,   &
               wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num, wallo(iwallo)%trn(itrn)%num,         &
               (wallo(iwallo)%trn(itrn)%src(isrc)%typ, wallo(iwallo)%trn(itrn)%src(isrc)%num,                    &
               wal_oma(iwallo)%trn(itrn)%src(isrc)%hd, isrc = 1, wallo(iwallo)%trn(itrn)%src_num)

--- a/src/wallo_use_output.f90
+++ b/src/wallo_use_output.f90
@@ -18,7 +18,7 @@
           write (3110,*) time%day, time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omd(iuse)
 
           if (pco%csvout == "y") then
-          write (3114,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omd(iuse)
+          write (3114,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omd(iuse)
           end if
         end if
        
@@ -34,7 +34,7 @@
           write (3111,*) time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omm(iuse)
  
           if (pco%csvout == "y") then
-          write (3115,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omm(iuse)
+          write (3115,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omm(iuse)
           end if
         end if
 
@@ -51,7 +51,7 @@
           write (3112,*) time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omy(iuse)
   
               if (pco%csvout == "y") then
-          write (3116,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omy(iuse)
+          write (3116,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_omy(iuse)
           end if
         end if
 
@@ -68,7 +68,7 @@
         write (3113,*) time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_oma(iuse)
 
         if (pco%csvout == "y") then
-        write (3117,'(*(G0.3,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_oma(iuse)
+        write (3117,'(*(G0.6,:","))') time%mo, time%day_mo, time%yrc, iuse, om_use_name(iuse), wal_use_oma(iuse)
         end if
        end if
       end if

--- a/src/wet_cs_output.f90
+++ b/src/wet_cs_output.f90
@@ -54,7 +54,7 @@
                          (wetcs_d(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                           wetcs_d(j)%cs(1)%volm
         if (pco%csvout == "y") then
-          write (6091,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (6091,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (wetcs_d(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                         (wetcs_d(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                         (wetcs_d(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -105,7 +105,7 @@
                            (wetcs_m(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                             wetcs_m(j)%cs(1)%volm
           if (pco%csvout == "y") then
-            write (6093,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (6093,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (wetcs_m(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                           (wetcs_m(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                           (wetcs_m(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -171,7 +171,7 @@
                            (wetcs_y(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                             wetcs_y(j)%cs(1)%volm
           if (pco%csvout == "y") then
-            write (6095,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (6095,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (wetcs_y(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                           (wetcs_y(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                           (wetcs_y(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &
@@ -230,7 +230,7 @@
                          (wetcs_a(j)%cs(ics)%conc,ics=1,cs_db%num_cs), &
                           wetcs_a(j)%cs(1)%volm
         if (pco%csvout == "y") then
-          write (6097,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (6097,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (wetcs_a(j)%cs(ics)%inflow,ics=1,cs_db%num_cs), &
                                         (wetcs_a(j)%cs(ics)%outflow,ics=1,cs_db%num_cs), &
                                         (wetcs_a(j)%cs(ics)%seep,ics=1,cs_db%num_cs), &

--- a/src/wet_salt_output.f90
+++ b/src/wet_salt_output.f90
@@ -50,7 +50,7 @@
                          (wetsalt_d(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                           wetsalt_d(j)%salt(1)%volm
         if (pco%csvout == "y") then
-          write (5091,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (5091,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (wetsalt_d(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                         (wetsalt_d(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                         (wetsalt_d(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -95,7 +95,7 @@
                            (wetsalt_m(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             wetsalt_m(j)%salt(1)%volm
           if (pco%csvout == "y") then
-            write (5093,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (5093,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (wetsalt_m(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                           (wetsalt_m(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                           (wetsalt_m(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -153,7 +153,7 @@
                            (wetsalt_y(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                             wetsalt_y(j)%salt(1)%volm
           if (pco%csvout == "y") then
-            write (5095,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+            write (5095,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                           (wetsalt_y(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                           (wetsalt_y(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                           (wetsalt_y(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &
@@ -204,7 +204,7 @@
                          (wetsalt_a(j)%salt(isalt)%conc,isalt=1,cs_db%num_salts), &
                           wetsalt_a(j)%salt(1)%volm
         if (pco%csvout == "y") then
-          write (5097,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
+          write (5097,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, & 
                                         (wetsalt_a(j)%salt(isalt)%inflow,isalt=1,cs_db%num_salts), &
                                         (wetsalt_a(j)%salt(isalt)%outflow,isalt=1,cs_db%num_salts), &
                                         (wetsalt_a(j)%salt(isalt)%seep,isalt=1,cs_db%num_salts), &

--- a/src/wetland_output.f90
+++ b/src/wetland_output.f90
@@ -20,7 +20,7 @@
             write (2548,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_d(j), wet(j), &
             wet_in_d(j), wet_out_d(j)
              if (pco%csvout == "y") then
-               write (2552,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+               write (2552,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                wet_wat_d(j), wet(j), wet_in_d(j), wet_out_d(j)
              end if
           end if 
@@ -46,7 +46,7 @@
             write (2549,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_m(j), wet(j), &
             wet_in_m(j), wet_out_m(j)
               if (pco%csvout == "y") then
-                write (2553,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                write (2553,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                 wet_wat_m(j), wet(j), wet_in_m(j), wet_out_m(j)
               end if 
           end if
@@ -66,7 +66,7 @@
             write (2550,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_y(j), wet(j), &
             wet_in_y(j), wet_out_y(j)
               if (pco%csvout == "y") then
-                write (2554,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                write (2554,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
                 wet_wat_y(j), wet(j), wet_in_y(j), wet_out_y(j)
               end if
           end if
@@ -83,7 +83,7 @@
           write (2551,100) time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_a(j), wet(j), &
           wet_in_a(j), wet_out_a(j)
           if (pco%csvout == "y") then
-            write (2555,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_a(j), &
+            write (2555,'(*(G0.6,:","))') time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, wet_wat_a(j), &
             wet(j), wet_in_a(j), wet_out_a(j)
           end if 
         end if


### PR DESCRIPTION
* Fix basin_output.f90, line 122: basin_nb_mon.csv output file was not printing commas for value lines
* Fix header_sd_channel.f90, line 173: was writing to file channel_mon_sdmorph.csv instead of channel_sdmorph_mon.csv
* Fix output_landscape_init.f90, line 409: was writing name hru_plcarb_day.csv to files_out.out instead of hru_scf_day.csv
* Change all instances of (*(G0.3,:,",")) and (*(G0.3,:",")) for csv output files to use G0.6 instead. G0.3 used 3 significant digits total, including before the decimal, causing rounding of a number like 123.678 to print as 124. in the csv files. G0.6 allows for more significant digits that still works well with scientific or fixed notation

Please feel free to reject if the timing of changes to these files is not good for you. These changes are easily repeatable in the future as needed.