### PR TITLE
wro - Refactor transfer execution and org_min record handling

### DIFF
--- a/src/recall_read.f90
+++ b/src/recall_read.f90
@@ -117,26 +117,27 @@
       istep = 0
       idaystep = 0
 
-      do 
-        open (108,file = recall_db(irec)%org_min%name)
-        read (108,*,iostat=eof) titldum
-        if (eof < 0) exit
-        read (108,*,iostat=eof) nbyr
-        if (eof < 0) exit
-        read (108,*,iostat=eof) header
-        exit 
-      end do
-        
-      !! check if the org mineral has already been used in a previous recall object
-      do iprev = 1, irec
-        if (recall_db(irec)%org_min%name == recall_db(irec)%org_min%name) then
-          recall_db(irec)%iorg_min = iprev
+      !! Set pointer to org_min with same name as current record.
+      recall_db(irec)%iorg_min = irec
+      !! Loop through previous records to find org_min with same name and set pointer to that record if found.
+      do iprev = 1, irec - 1
+        if (recall_db(irec)%org_min%name == recall_db(iprev)%org_min%name) then
+          recall_db(irec)%iorg_min = recall_db(iprev)%iorg_min
           exit
         end if
       end do
-          
-      !! if new org mineral, then read
+
       if (recall_db(irec)%iorg_min == irec) then
+        !! Read header to get nbyr and time-step type before allocating arrays.
+        do 
+          open (108,file = recall_db(irec)%org_min%name)
+          read (108,*,iostat=eof) titldum
+          if (eof < 0) exit
+          read (108,*,iostat=eof) nbyr
+          if (eof < 0) exit
+          read (108,*,iostat=eof) header
+          exit 
+        end do
                 
         select case (recall_db(irec)%org_min%tstep)
             

--- a/src/sd_channel_control3.f90
+++ b/src/sd_channel_control3.f90
@@ -324,13 +324,19 @@
 
       ich = isdch
             
-      !! allocate water for transfers that don't include a channel as a source
+      !! Execute scheduled transfers sourced from this channel (ich) for each
+      !! water allocation object; stop when trn_cur is exhausted or points
+      !! to a different source channel.
       if (db_mx%wallo_db > 0) then
         do iwallo = 1, db_mx%wallo_db
-          do while (wallo(iwallo)%trn(wallo(iwallo)%trn_cur)%ch_src == ich)
+          do while (wallo(iwallo)%trn_cur > 0)
+            !! All transfers for this object have been processed.
+            if (wallo(iwallo)%trn_cur > wallo(iwallo)%trn_obs) exit
+            !! Next transfer belongs to a different source channel.
+            if (wallo(iwallo)%trn(wallo(iwallo)%trn_cur)%ch_src /= ich) exit
             iw = iwallo
-            trn_m3 = ht2%flo
-            if (wallo(iwallo)%trn_cur <= wallo(iwallo)%trn_obs) call wallo_control (iw)
+            trn_m3 = ht2%flo   !available supply (m3) for this transfer
+            call wallo_control (iw)
           end do
         end do
       end if


### PR DESCRIPTION
This pull request refactors and improves logic in two Fortran source files, focusing on more robust handling of organic mineral records in `recall_read` and clarifying water transfer scheduling in `sd_channel_control3`. The changes enhance code clarity, ensure correct pointer assignment for shared resources, and improve the reliability of transfer execution.

**Improvements to organic mineral record handling (`recall_read.f90`):**
- Refactored the logic for assigning the `iorg_min` pointer so that it always points to the first record with the same `org_min%name`, ensuring shared resources are correctly referenced and avoiding redundant reads.
- Removed the previous, less robust check for duplicate organic minerals and streamlined the logic for reading new records only when necessary.

**Enhancements to water transfer scheduling (`sd_channel_control3.f90`):**
- Updated the loop controlling scheduled water transfers to more clearly and reliably process only those transfers sourced from the current channel, with improved exit conditions and comments for maintainability.