### PR TITLE
Update crop yield calculations to handle year skip condition

### DIFF
--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -276,13 +276,15 @@
         !! write annual basin crop yields and harvested areas
         if (sp_ob%hru > 0) then
         do iplt = 1, basin_plants
-          crop_yld_t_ha = bsn_crop_yld(iplt)%yield / (bsn_crop_yld(iplt)%area_ha + 1.e-6)
-          if (pco%crop_yld == "y" .or. pco%crop_yld == "b") then
-            write (5100,*) time%yrc, iplt, plts_bsn(iplt), bsn_crop_yld(iplt)%area_ha,            &
-                                                bsn_crop_yld(iplt)%yield, crop_yld_t_ha
+          if (time%yrs > pco%nyskip) then
+            crop_yld_t_ha = bsn_crop_yld(iplt)%yield / (bsn_crop_yld(iplt)%area_ha + 1.e-6)
+            if (pco%crop_yld == "y" .or. pco%crop_yld == "b") then
+              write (5100,*) time%yrc, iplt, plts_bsn(iplt), bsn_crop_yld(iplt)%area_ha,          &
+                                                  bsn_crop_yld(iplt)%yield, crop_yld_t_ha
+            end if
+            bsn_crop_yld_aa(iplt)%area_ha = bsn_crop_yld_aa(iplt)%area_ha + bsn_crop_yld(iplt)%area_ha
+            bsn_crop_yld_aa(iplt)%yield = bsn_crop_yld_aa(iplt)%yield + bsn_crop_yld(iplt)%yield
           end if
-          bsn_crop_yld_aa(iplt)%area_ha = bsn_crop_yld_aa(iplt)%area_ha + bsn_crop_yld(iplt)%area_ha
-          bsn_crop_yld_aa(iplt)%yield = bsn_crop_yld_aa(iplt)%yield + bsn_crop_yld(iplt)%yield
           bsn_crop_yld(iplt) = bsn_crop_yld_z
           if (time%end_sim == 1) then
             crop_yld_t_ha = bsn_crop_yld_aa(iplt)%yield / (bsn_crop_yld_aa(iplt)%area_ha + 1.e-6)


### PR DESCRIPTION
This pull request ensures that crop yield and harvested area outputs are skipped for the initial spin-up years, improving the accuracy of reported results.

* Output logic improvement:
  * Added a condition to only write annual basin crop yields and harvested areas after the number of years specified by `pco%nyskip`, preventing reporting during spin-up years. (`src/time_control.f90`)