### PR TITLE
bug fixed: use wrong index when count HRUs per cell

### DIFF
--- a/src/gwflow_read.f90
+++ b/src/gwflow_read.f90
@@ -2395,7 +2395,7 @@
           endif
           backspace(in_cell_hru)
         enddo
-31      cell_num_hrus(cell_num) = hru_count
+31      cell_num_hrus(hru_cell) = hru_count
       enddo
       max_hrus = maxval(cell_num_hrus(1:ncell))
       !rewind and re-read headers
@@ -2430,7 +2430,7 @@
           endif
           backspace(in_cell_hru)
         enddo
-30      cell_num_hrus(cell_num) = hru_count
+30      cell_num_hrus(hru_cell) = hru_count
       enddo
       else
         write(out_gw,*) '          gwflow.cellhru not found; cell-HRU reverse mapping not available'


### PR DESCRIPTION
When counting HRUs per cell, the `cell_num` is read from the next line in `gwflow.cellhru`, and is assigned the next valid cell's index by `cell_num = cell_id_list(cell_num)`. So, `cell_num_hrus(cell_num) = hru_count` should be `cell_num_hrus(hru_cell) = hru_count`.

This bug can be tested when trying to access each HRU of each cell, for example:
```
do i=1,ncell
        if(gw_state(i)%stat.eq.1) then
        if (cell_num_hrus(i) > 0) then
            do j=1,cell_num_hrus(i)
             if (cell_hrus(i, j)) == 0) then
                print *, i, j
             endif
            enddo
    endif
  endif
enddo
```