### PR TITLE
bug fixed: allocate variables when water_treat.wal and water_use.wal …

### DIFF
--- a/src/water_treatment_read.f90
+++ b/src/water_treatment_read.f90
@@ -26,6 +26,13 @@
       inquire (file='water_treat.wal', exist=i_exist)
       if (.not. i_exist .or. 'water_treat.wal' == "null") then
         allocate (wtp(0:0))
+        allocate (wtp_om_stor(0:0))
+        allocate (wtp_cs_stor(0:0))
+        allocate (wtp_om_out(0:0))
+        allocate (wal_tr_omd(0:0))
+        allocate (wal_tr_omm(0:0))
+        allocate (wal_tr_omy(0:0))
+        allocate (wal_tr_oma(0:0))
       else
       do 
         open (107,file='water_treat.wal')

--- a/src/water_use_read.f90
+++ b/src/water_use_read.f90
@@ -26,7 +26,14 @@
 
       inquire (file='water_use.wal', exist=i_exist)
       if (.not. i_exist .or. 'water_use.wal' == "null") then
-        allocate (wuse(0:0))
+        allocate (wuse(0:0))          
+        allocate (wuse_om_stor(0:0))
+        allocate (wuse_om_out(0:0))
+        allocate (wuse_cs_stor(0:0))
+        allocate (wal_use_omd(0:0))
+        allocate (wal_use_omm(0:0))
+        allocate (wal_use_omy(0:0))
+        allocate (wal_use_oma(0:0))
       else
       do 
         open (107,file='water_use.wal')


### PR DESCRIPTION
This PR includes:
+ Bug fixed: Allocate variables to zero-length when the required input file does not exist, including the source files `water_tratement_read.f90` and `water_use_read.f90`

