### PR TITLE
Addition of irr_day decision table variable

### DIFF
--- a/src/actions.f90
+++ b/src/actions.f90
@@ -35,8 +35,7 @@
       external :: cn2_init, cs_fert, curno, hru_fr_change, hru_lum_init, mgt_harvbiomass, mgt_harvgrain, &
                   mgt_harvresidue, mgt_harvtuber, mgt_killop, mgt_newtillmix, mgt_newtillmix_wet, &
                   mgt_transplant, pest_apply, pl_burnop, pl_fert, pl_fert_wet, pl_graze, pl_manure, &
-                  plant_init, salt_fert, structure_set_parms, wet_initial, chg_par, mgt_newtillmix_cswat1, &
-                  mgt_newtillmix_cswat0
+                  plant_init, salt_fert, structure_set_parms, wet_initial, chg_par
 
       integer, intent (in)  :: ob_cur      !none     |sequential number of individual objects
       integer, intent (in)  :: ob_num      !none     |sequential number for all objects
@@ -146,7 +145,9 @@
                 if (d_tbl%act(iac)%file_pointer == "unlim") then
                   irrig(j)%applied = irrop_db(irrop)%amt_mm * irrop_db(irrop)%eff * (1. - irrop_db(irrop)%surq)
                   irrig(j)%runoff = irrop_db(irrop)%amt_mm * irrop_db(irrop)%eff * irrop_db(irrop)%surq
-                end if  
+                end if
+                ! save the Julian day of this irrigation
+                hru(j)%last_irr_day = time%day
               
                 !set organics and constituents from irr.ops ! irrig(j)%water =  cs_irr(j) = 
                 if (pco%mgtout == "y") then
@@ -275,6 +276,8 @@
                   
             ! add irrigation to yearly sum for dtbl conditioning jga 6-25
             hru(j)%irr_yr = hru(j)%irr_yr + irrig(j)%applied
+            ! save the Julian day of this irrigation
+            hru(j)%last_irr_day = time%day
             
             if (d_tbl%act(iac)%name=='ponding') then !paddy irrigation
               if (pco%mgtout == "y") then
@@ -366,11 +369,7 @@
             if (pcom(j)%dtbl(idtbl)%num_actions(iac) <= Int(d_tbl%act(iac)%const2)) then
               idtill = d_tbl%act_typ(iac)
               ipl = 1
-              if (bsn_cc%cswat == 1) then
-                call mgt_newtillmix_cswat1(j, 0., idtill)
-              else
-                call mgt_newtillmix_cswat0(j, 0., idtill)
-              endif
+              call mgt_newtillmix(j, 0., idtill)
             
               if (pco%mgtout == "y") then
                 write (2612, *) j, time%yrc, time%mo, time%day_mo, tilldb(idtill)%tillnm, "    TILLAGE",    &
@@ -386,6 +385,8 @@
           case ("plant")
             j = d_tbl%act(iac)%ob_num
             if (j == 0) j = ob_cur
+            
+            if (pcom(j)%dtbl(idtbl)%num_actions(iac) <= Int(d_tbl%act(iac)%const2)) then
                 
             icom = pcom(j)%pcomdb
             pcom(j)%days_plant = 1       !reset days since last planting
@@ -438,6 +439,7 @@
               pcom(j)%dtbl(idtbl)%num_actions(iac) = pcom(j)%dtbl(idtbl)%num_actions(iac) + 1
               pcom(j)%dtbl(idtbl)%days_act(iac) = 1     !reset days since last action
               if (iac > 1) pcom(j)%dtbl(idtbl)%days_act(iac-1) =  0     !reset previous action day counter
+            end if
             
           !harvest only
           case ("harvest")
@@ -941,11 +943,7 @@
               if (wet_ob(j)%depth > 0.001) then
                 call mgt_newtillmix_wet(j,idtill) 
               else
-                if (bsn_cc%cswat == 1) then
-                  call mgt_newtillmix_cswat1(j,0.,idtill) 
-                else
-                  call mgt_newtillmix_cswat0(j,0.,idtill) 
-                endif
+                call mgt_newtillmix(j,0.,idtill) 
               endif
               pcom(j)%dtbl(idtbl)%num_actions(iac) = pcom(j)%dtbl(idtbl)%num_actions(iac) + 1
 

--- a/src/conditions.f90
+++ b/src/conditions.f90
@@ -248,6 +248,24 @@
           ivar_cur = pcom(ob_num)%days_irr
           ivar_tbl = int(d_tbl%cond(ic)%lim_const)
           call cond_integer (ic, ivar_cur, ivar_tbl)
+        
+        !days since last physical water application 
+        case ("irr_day")
+          ob_num = d_tbl%cond(ic)%ob_num
+          if (ob_num == 0) ob_num = ob_cur
+          
+          ! bulletproof check: If it has NEVER irrigated (0 or -999), force a pass
+          if (hru(ob_num)%last_irr_day == 0 .or. hru(ob_num)%last_irr_day == -999) then
+             ivar_cur = 999 
+          else
+             ! calculate normal days since last irrigation
+             ivar_cur = time%day - hru(ob_num)%last_irr_day
+             ! fix for crossing the New Year (Jan 1st - Dec 31st)
+             if (ivar_cur < 0) ivar_cur = ivar_cur + 365 
+          end if
+          
+          ivar_tbl = int(d_tbl%cond(ic)%lim_const)
+          call cond_integer (ic, ivar_cur, ivar_tbl)
                                          
         !days since last action
         case ("days_act")

--- a/src/hru_module.f90
+++ b/src/hru_module.f90
@@ -267,6 +267,7 @@
         real :: irr_hmin = 0                    !mm H2O     |threshold ponding depth to trigger paddy irrigation
         real :: irr_isc = 0                     !mm H2O     |ID of the source cha/res/aqu for paddy irrigation
         real, dimension(5) :: flow = 0          !mm H2O     |average annual flow (1=wyld,2=perc,3=surface,4=lateral,5=tile)
+        integer :: last_irr_day = -999          !none       |julian day of last irrigation event
       end type hydrologic_response_unit
       type (hydrologic_response_unit), dimension(:), allocatable, target :: hru
       type (hydrologic_response_unit), dimension(:), allocatable, target :: hru_init


### PR DESCRIPTION
Added the decision table variable "irr_day", which when used along with auto-irrigation will not allow irrigation events to occur within a user-specified number of days. The purpose of the addition of this variable is to help simulate limitations of certain irrigation types (center pivot, wheel line, furrow) which are often set to apply greater water depths at lower frequencies.