### PR TITLE
Add new header types and wilting-point water output to hydrograph_module

### DIFF
--- a/src/hydrograph_module.f90
+++ b/src/hydrograph_module.f90
@@ -722,6 +722,56 @@
         character (len=15) :: layer10 = "       st_mm_10"        !!mm H2O       |amt of water stored in layer 10
       end type sol_header
       type (sol_header) :: sol_hdr
+
+      type sol_nut_ly_header
+        character (len=15) :: no3     = "            no3"   !!kg N/ha      |nitrate
+        character (len=15) :: nh4     = "            nh4"   !!kg N/ha      |ammonium
+        character (len=15) :: hact_n  = "         hact_n"   !!kg N/ha      |active humus N
+        character (len=15) :: hsta_n  = "         hsta_n"   !!kg N/ha      |stable humus N
+        character (len=15) :: hs_n    = "           hs_n"   !!kg N/ha      |slow humus N
+        character (len=15) :: hp_n    = "           hp_n"   !!kg N/ha      |passive humus N
+        character (len=15) :: rsd_n   = "          rsd_n"   !!kg N/ha      |residue N
+        character (len=15) :: wsol_p  = "         wsol_p"   !!kg P/ha      |water soluble P
+        character (len=15) :: lab_p   = "          lab_p"   !!kg P/ha      |labile P
+        character (len=15) :: act_p   = "          act_p"   !!kg P/ha      |active mineral P
+        character (len=15) :: sta_p   = "          sta_p"   !!kg P/ha      |stable mineral P
+        character (len=15) :: hact_p  = "         hact_p"   !!kg P/ha      |active humus P
+        character (len=15) :: hsta_p  = "         hsta_p"   !!kg P/ha      |stable humus P
+        character (len=15) :: hs_p    = "           hs_p"   !!kg P/ha      |slow humus P
+        character (len=15) :: hp_p    = "           hp_p"   !!kg P/ha      |passive humus P
+        character (len=15) :: rsd_p   = "          rsd_p"   !!kg P/ha      |residue P
+      end type sol_nut_ly_header
+      type (sol_nut_ly_header) :: sol_nut_ly_hdr
+
+      type sol_nut_pr_header
+        character (len=15) :: no3     = "            no3"   !!kg N/ha      |profile nitrate
+        character (len=15) :: nh4     = "            nh4"   !!kg N/ha      |profile ammonium
+        character (len=15) :: wsol_p  = "         wsol_p"   !!kg P/ha      |profile water soluble P
+        character (len=15) :: lab_p   = "          lab_p"   !!kg P/ha      |profile labile P
+        character (len=15) :: act_p   = "          act_p"   !!kg P/ha      |profile active mineral P
+        character (len=15) :: sta_p   = "          sta_p"   !!kg P/ha      |profile stable mineral P
+        character (len=15) :: hact_m  = "         hact_m"   !!kg/ha        |profile active humus mass
+        character (len=15) :: hact_c  = "         hact_c"   !!kg C/ha      |profile active humus C
+        character (len=15) :: hact_n  = "         hact_n"   !!kg N/ha      |profile active humus N
+        character (len=15) :: hact_p  = "         hact_p"   !!kg P/ha      |profile active humus P
+        character (len=15) :: hsta_m  = "         hsta_m"   !!kg/ha        |profile stable humus mass
+        character (len=15) :: hsta_c  = "         hsta_c"   !!kg C/ha      |profile stable humus C
+        character (len=15) :: hsta_n  = "         hsta_n"   !!kg N/ha      |profile stable humus N
+        character (len=15) :: hsta_p  = "         hsta_p"   !!kg P/ha      |profile stable humus P
+        character (len=15) :: hs_m    = "           hs_m"   !!kg/ha        |profile slow humus mass
+        character (len=15) :: hs_c    = "           hs_c"   !!kg C/ha      |profile slow humus C
+        character (len=15) :: hs_n    = "           hs_n"   !!kg N/ha      |profile slow humus N
+        character (len=15) :: hs_p    = "           hs_p"   !!kg P/ha      |profile slow humus P
+        character (len=15) :: hp_m    = "           hp_m"   !!kg/ha        |profile passive humus mass
+        character (len=15) :: hp_c    = "           hp_c"   !!kg C/ha      |profile passive humus C
+        character (len=15) :: hp_n    = "           hp_n"   !!kg N/ha      |profile passive humus N
+        character (len=15) :: hp_p    = "           hp_p"   !!kg P/ha      |profile passive humus P
+        character (len=15) :: rsd_m   = "          rsd_m"   !!kg/ha        |profile residue mass
+        character (len=15) :: rsd_c   = "          rsd_c"   !!kg C/ha      |profile residue C
+        character (len=15) :: rsd_n   = "          rsd_n"   !!kg N/ha      |profile residue N
+        character (len=15) :: rsd_p   = "          rsd_p"   !!kg P/ha      |profile residue P
+      end type sol_nut_pr_header
+      type (sol_nut_pr_header) :: sol_nut_pr_hdr
       
       type plant_header        
         character (len=17) :: name =  "     name        "       !!none         |plant name 

--- a/src/hydrograph_module.f90
+++ b/src/hydrograph_module.f90
@@ -2,6 +2,8 @@
       
       use time_module
       use basin_module
+      use hru_module, only : hru
+      use soil_data_module, only : soildb
       
       implicit none
       
@@ -1648,5 +1650,56 @@
 !        dr1%lag = const
 !        dr1%grv = const
 !      end function dr_constant
+
+      integer function case6_header_layers(obtypno)
+        integer, intent(in) :: obtypno
+
+        integer :: ihru = 0
+        integer :: layer_count = 0
+
+        case6_header_layers = 1
+
+        if (obtypno == 0) then
+          do ihru = 1, sp_ob%hru
+            layer_count = soil_layers_for_hru(ihru)
+            case6_header_layers = Max(case6_header_layers, layer_count)
+          end do
+        else
+          case6_header_layers = soil_layers_for_hru(obtypno)
+        end if
+      end function case6_header_layers
+
+      integer function soil_layers_for_hru(ihru)
+        integer, intent(in) :: ihru
+
+        integer :: isol = 0
+
+        soil_layers_for_hru = 1
+        isol = hru(ihru)%dbs%soil
+        if (isol > 0) then
+          soil_layers_for_hru = soildb(isol)%s%nly
+          if (soildb(isol)%ly(1)%z > 19.5) soil_layers_for_hru = soil_layers_for_hru + 1
+        end if
+      end function soil_layers_for_hru
+
+      subroutine write_case6_header(iunit, obtypno)
+        integer, intent(in) :: iunit
+        integer, intent(in) :: obtypno
+
+        integer :: nly = 0
+        integer :: nly_hdr = 0
+        character(len=15), dimension(:), allocatable :: sol_hdr_dyn
+        character(len=200) :: solHdrFmt = ""
+
+        nly_hdr = case6_header_layers(obtypno)
+        allocate(sol_hdr_dyn(nly_hdr))
+        do nly = 1, nly_hdr
+          write(sol_hdr_dyn(nly), '(A,I0)') '       st_mm_', nly
+        end do
+        write(solHdrFmt, '(A,I0,A)') '(A11,A12,A12,A13,1X,A9,1X,A10,2X,', nly_hdr, '(A16))'
+        write (iunit,solHdrFmt) hyd_hdr_time%day, hyd_hdr_time%mo, hyd_hdr_time%day_mo, hyd_hdr_time%yrc, &
+          hyd_hdr_time%name, 'obj_type', (sol_hdr_dyn(nly), nly = 1, nly_hdr)
+        deallocate(sol_hdr_dyn)
+      end subroutine write_case6_header
       
       end module hydrograph_module

--- a/src/object_read_output.f90
+++ b/src/object_read_output.f90
@@ -109,6 +109,10 @@
          !write (iunit+i,*) hyd_hdr_time, hyd_hdr
          case (6)
            write (iunit+i,*) hyd_hdr_time, sol_hdr
+         case (7)
+           write (iunit+i,*) hyd_hdr_time, sol_nut_ly_hdr
+         case (8)
+           write (iunit+i,*) hyd_hdr_time, sol_nut_pr_hdr
          case (9)
            write (iunit+i, '(1X4A,16(4XA),2A,14(4XA))') hyd_hdr_time, plt_hdr, plt_hdr
          case (10)

--- a/src/object_read_output.f90
+++ b/src/object_read_output.f90
@@ -108,7 +108,7 @@
          !case (1-5)
          !write (iunit+i,*) hyd_hdr_time, hyd_hdr
          case (6)
-           write (iunit+i,*) hyd_hdr_time, sol_hdr
+           call write_case6_header(iunit+i, ob_out(i)%obtypno)
          case (7)
            write (iunit+i,*) hyd_hdr_time, sol_nut_ly_hdr
          case (8)

--- a/src/output_landscape_init.f90
+++ b/src/output_landscape_init.f90
@@ -506,6 +506,18 @@
               write (9000,*) "HRU                       hru_begsim_soil_prop.csv"
             endif
 
+            !! write beginning of simulation wilting-point water by layer
+            call open_output_file(4588, "hru_begsim_wp_lyr.txt", 1500)
+            write (4588,*)  bsn%name, prog
+            write (4588,*) begsim_wp_lyr_hdr
+            write (9000,*) "HRU                       hru_begsim_wp_lyr.txt"
+            if (pco%csvout == "y") then
+              call open_output_file(4589, "hru_begsim_wp_lyr.csv", 1500)
+              write (4589,*)  bsn%name, prog
+              write (4589,'(*(G0.6,:,","))') begsim_wp_lyr_hdr
+              write (9000,*) "HRU                       hru_begsim_wp_lyr.csv"
+            endif
+
             !! write end of simulation soil properties headers to hru_endsim_soil_prop
             call open_output_file(4584, "hru_endsim_soil_prop.txt", 1500)
             write (4584,*)  bsn%name, prog

--- a/src/output_landscape_module.f90
+++ b/src/output_landscape_module.f90
@@ -1192,6 +1192,22 @@
          character(len=15)  :: ph            =    "             ph"  
          end type output_endsim_soil_prop_header
       type (output_endsim_soil_prop_header) ::endsim_soil_prop_hdr
+
+      type output_begsim_wp_lyr_header
+        character (len=7)  :: freq          =    "freq   "
+        character (len=16) :: soil_name     =    "            soil"
+        character (len=4)  :: soil_lyr      =    "lyrs"
+        character (len=6)  :: soil_depth    =    " depth"
+        character (len=3)  :: mo            =    "mon"
+        character (len=3)  :: day_mo        =    "day"
+        character (len=5)  :: yrc           =    "   yr"
+        character (len=5)  :: hru           =    "  hru"
+        character (len=8)  :: gis_id        =    "  gis_id"
+        character (len=16) :: name          =    "            name"
+        character (len=10) :: wp            =    "        wp"
+        character (len=10) :: wpmm          =    "      wpmm"
+      end type output_begsim_wp_lyr_header
+      type (output_begsim_wp_lyr_header) :: begsim_wp_lyr_hdr
       
 
 

--- a/src/soil_nutcarb_write.f90
+++ b/src/soil_nutcarb_write.f90
@@ -17,6 +17,7 @@
       use carbon_module
       use basin_module
       use plant_module
+      use output_landscape_module
       
       implicit none
       
@@ -85,6 +86,12 @@
                               soil(j)%phys(ly)%clay, soil(j)%phys(ly)%silt, soil(j)%phys(ly)%sand, soil(j)%phys(ly)%rock, &
                               soil(j)%ly(ly)%alb, soil(j)%ly(ly)%usle_k, soil(j)%ly(ly)%ec, soil(j)%ly(ly)%cal, soil(j)%ly(ly)%ph
               enddo
+
+              do ly = 1, soil(j)%nly
+                write (4588,*) freq_label, soil(j)%snam, ly, int(soil(j)%phys(ly)%d), time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                              soil(j)%phys(ly)%wp, soil(j)%phys(ly)%wpmm
+              enddo
+
               if (pco%csvout == "y") then
                 do ly = 1, soil(j)%nly
                   write (4587,'(*(G0.7,:,","))') freq_label, soil(j)%snam, ly, int(soil(j)%phys(ly)%d), time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
@@ -92,6 +99,11 @@
                               soil(j)%phys(ly)%bd, soil(j)%phys(ly)%awc, soil(j)%phys(ly)%k, soil(j)%phys(ly)%cbn, &
                               soil(j)%phys(ly)%clay, soil(j)%phys(ly)%silt, soil(j)%phys(ly)%sand, soil(j)%phys(ly)%rock, &
                               soil(j)%ly(ly)%alb, soil(j)%ly(ly)%usle_k, soil(j)%ly(ly)%ec, soil(j)%ly(ly)%cal, soil(j)%ly(ly)%ph
+                enddo
+
+                do ly = 1, soil(j)%nly
+                  write (4589,'(*(G0.7,:,","))') freq_label, soil(j)%snam, ly, int(soil(j)%phys(ly)%d), time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                                soil(j)%phys(ly)%wp, soil(j)%phys(ly)%wpmm
                 enddo
               endif
             endif


### PR DESCRIPTION
This pull request adds new output features and improves the flexibility of soil and nutrient data headers in the model. The main changes include new data structures for soil nutrient output, dynamic header writing for case 6 outputs, and the addition of new files for wilting-point water by soil layer at the beginning of the simulation.

**New output and header structures:**

* Added `sol_nut_ly_header` and `sol_nut_pr_header` types to `hydrograph_module.f90` for detailed soil nutrient layer and profile output headers, and integrated their use in output writing logic. [[1]](diffhunk://#diff-6f4f3d7223315e09416f82b69d74235626d4a5394c20d48494fe9cfea4c3779dR728-R777) [[2]](diffhunk://#diff-495c6c90d0d9dd716f778b519b78f11efdd41a78e241518cc9cfe895f69ab9e3L111-R115)
* Added `output_begsim_wp_lyr_header` type to `output_landscape_module.f90` to support new wilting-point water by layer outputs.

**Dynamic header and output writing:**

* Implemented `case6_header_layers`, `soil_layers_for_hru`, and `write_case6_header` functions/subroutines in `hydrograph_module.f90` to dynamically determine and write the correct number of soil layer headers for case 6 output. [[1]](diffhunk://#diff-6f4f3d7223315e09416f82b69d74235626d4a5394c20d48494fe9cfea4c3779dR1654-R1704) [[2]](diffhunk://#diff-6f4f3d7223315e09416f82b69d74235626d4a5394c20d48494fe9cfea4c3779dR5-R6)
* Updated `object_read_output.f90` to use the new dynamic header writing for case 6 and to output the new nutrient headers for cases 7 and 8.

**New wilting-point water output:**

* Added logic to `output_landscape_init.f90` and `soil_nutcarb_write.f90` to write new files (`hru_begsim_wp_lyr.txt` and `.csv`) containing wilting-point water by soil layer at the beginning of the simulation, including new header and data writing routines. [[1]](diffhunk://#diff-7ab2dbed3594ef3614b2d2eba9bedd69582688b5268a0cd230e7dfdf7e2bb449R509-R520) [[2]](diffhunk://#diff-5045c8ff70b7f6c38ceb785ee39b5200686416525b4bf01f8ca93489be7f67a0R20) [[3]](diffhunk://#diff-5045c8ff70b7f6c38ceb785ee39b5200686416525b4bf01f8ca93489be7f67a0R89-R94) [[4]](diffhunk://#diff-5045c8ff70b7f6c38ceb785ee39b5200686416525b4bf01f8ca93489be7f67a0R103-R107)

These changes improve the model's output capabilities, especially for soil nutrient and water content reporting, and make the output more flexible and informative for multi-layered soil structures.