### PR TITLE
perf(read): O(1) name->index lookup in hru_read (was O(N_hru x N_db))

### DIFF
--- a/src/hru_read.f90
+++ b/src/hru_read.f90
@@ -9,11 +9,19 @@
       use input_file_module
       use hru_module, only : hru_db, ihru, sol_plt_ini, snodb
       use constituent_mass_module
-      
+      use name_index_module
+
       implicit none
-      
+
       external :: allocate_parms
-      
+
+      ! name->index hash maps so per-HRU database lookups are O(1) instead of an
+      ! O(N_hru x N_db) linear scan (the per-HRU topography/hydrology matching on
+      ! large models was a top for_cpstr_eq startup hotspot).
+      type (name_index) :: ix_topo, ix_hyd, ix_soil, ix_field
+      character (len=40), allocatable :: nm(:)
+      integer :: jj = 0               !none       |index-build counter
+
       character (len=80) :: titldum = ""!           |title of file
       character (len=80) :: header = "" !           |header of file
       integer :: eof = 0              !           |end of file
@@ -53,6 +61,29 @@
           end do
           
         allocate (hru_db(0:imax))
+
+        ! build name->index maps once for the databases with many entries
+        ! (topography and hydrology are per-HRU and dominate the O(N^2) scan)
+        if (db_mx%topo > 0) then
+          allocate (nm(db_mx%topo))
+          do jj = 1, db_mx%topo; nm(jj) = topo_db(jj)%name; end do
+          call nix_build (ix_topo, nm, db_mx%topo); deallocate (nm)
+        end if
+        if (db_mx%hyd > 0) then
+          allocate (nm(db_mx%hyd))
+          do jj = 1, db_mx%hyd; nm(jj) = hyd_db(jj)%name; end do
+          call nix_build (ix_hyd, nm, db_mx%hyd); deallocate (nm)
+        end if
+        if (db_mx%soil > 0) then
+          allocate (nm(db_mx%soil))
+          do jj = 1, db_mx%soil; nm(jj) = soildb(jj)%s%snam; end do
+          call nix_build (ix_soil, nm, db_mx%soil); deallocate (nm)
+        end if
+        if (db_mx%field > 0) then
+          allocate (nm(db_mx%field))
+          do jj = 1, db_mx%field; nm(jj) = field_db(jj)%name; end do
+          call nix_build (ix_field, nm, db_mx%field); deallocate (nm)
+        end if
 
         rewind (113)
         read (113,*,iostat=eof) titldum
@@ -129,31 +160,19 @@
             exit
             end if
           end do
-          do ith = 1, db_mx%topo
-            if (hru_db(i)%dbsc%topo == topo_db(ith)%name) then
-               hru_db(i)%dbs%topo = ith
-            exit
-            end if
-          end do
-          
+          ith = nix_get (ix_topo, hru_db(i)%dbsc%topo)
+          if (ith > 0) hru_db(i)%dbs%topo = ith
+
          if (hru_db(i)%dbs%topo == 0) write (9001,*) hru_db(i)%dbsc%topo, "not found (topography.hyd)"
-        
-         do ithyd = 1, db_mx%hyd
-            if (hru_db(i)%dbsc%hyd == hyd_db(ithyd)%name) then
-               hru_db(i)%dbs%hyd = ithyd
-            exit
-            end if
-         end do
-         
+
+         ithyd = nix_get (ix_hyd, hru_db(i)%dbsc%hyd)
+         if (ithyd > 0) hru_db(i)%dbs%hyd = ithyd
+
          if (hru_db(i)%dbs%hyd == 0) write (9001,*) hru_db(i)%dbsc%hyd, "not found (hydrograph.hyd)"
-         
-         do isol = 1, db_mx%soil
-            if (hru_db(i)%dbsc%soil == soildb(isol)%s%snam) then
-               hru_db(i)%dbs%soil = isol
-            exit
-            end if
-         end do
-         
+
+         isol = nix_get (ix_soil, hru_db(i)%dbsc%soil)
+         if (isol > 0) hru_db(i)%dbs%soil = isol
+
          if (hru_db(i)%dbs%soil == 0) write (9001,*) hru_db(i)%dbsc%soil, "not found (soils.sol)"
 
          do isno = 1, db_mx%sno
@@ -165,13 +184,9 @@
          
          if (hru_db(i)%dbs%snow == 0 .and. hru_db(i)%dbsc%snow /= 'null') write (9001,*) hru_db(i)%dbsc%snow, "not found (snow.sno)"
          
-         do ifld = 1, db_mx%field
-             if (hru_db(i)%dbsc%field == field_db(ifld)%name) then
-               hru_db(i)%dbs%field = ifld
-            exit
-            end if
-         end do
-         
+         ifld = nix_get (ix_field, hru_db(i)%dbsc%field)
+         if (ifld > 0) hru_db(i)%dbs%field = ifld
+
         if (hru_db(i)%dbs%field == 0 .and. hru_db(i)%dbsc%field /= 'null') write (9001,*) &
           hru_db(i)%dbsc%field, "not found (field.fld)"
 

--- a/src/name_index_module.f90
+++ b/src/name_index_module.f90
@@ -1,0 +1,88 @@
+      module name_index_module
+      !! Small open-addressing hash map: database name (character) -> integer index.
+      !! Built once per database so per-HRU lookups in hru_read become O(1) instead of
+      !! an O(N_hru x N_db) linear scan (for_cpstr_eq was a top startup CPU hotspot on
+      !! large models, dominated by the per-HRU topography/hydrology name matching).
+      !! Preserves first-match semantics: if a name occurs more than once, the lowest
+      !! index wins, exactly like the original `do ... if (name==db) exit` scans.
+      implicit none
+      private
+      public :: name_index, nix_build, nix_get
+
+      integer, parameter :: NIX_KEYLEN = 40    !! >= longest db/target name (dbsc fields are len=40)
+
+      type name_index
+        integer :: tsize = 0
+        character(len=NIX_KEYLEN), allocatable :: keys(:)
+        integer, allocatable :: vals(:)        !! 0 = empty slot
+      end type name_index
+
+      contains
+
+      pure integer function nix_hash(key, tsize) result(h)
+        character(len=*), intent(in) :: key
+        integer, intent(in) :: tsize
+        integer :: i, n
+        integer(kind=8) :: acc
+        acc = 1469598103934665603_8            !! FNV-1a offset basis
+        n = len_trim(key)
+        do i = 1, n
+          acc = ieor(acc, int(iachar(key(i:i)), 8))
+          acc = acc * 1099511628211_8          !! FNV-1a prime (wraps; fine for hashing)
+        end do
+        h = int(iand(acc, int(huge(0), 8)), kind=4)
+        h = modulo(h, tsize) + 1
+      end function nix_hash
+
+      subroutine nix_build(idx, names, n)
+        type(name_index), intent(out) :: idx
+        integer, intent(in) :: n
+        character(len=*), intent(in) :: names(:)
+        integer :: i, slot
+        character(len=NIX_KEYLEN) :: key
+        logical :: dup
+        idx%tsize = max(16, 2 * max(n, 1))     !! load factor <= 0.5
+        allocate (idx%keys(idx%tsize)); idx%keys = ''
+        allocate (idx%vals(idx%tsize)); idx%vals = 0
+        do i = 1, n
+          key = names(i)
+          slot = nix_hash(key, idx%tsize)
+          dup = .false.
+          do
+            if (idx%vals(slot) == 0) exit
+            if (idx%keys(slot) == key) then    !! keep first occurrence (first-match)
+              dup = .true.; exit
+            end if
+            slot = slot + 1
+            if (slot > idx%tsize) slot = 1
+          end do
+          if (.not. dup) then
+            idx%keys(slot) = key
+            idx%vals(slot) = i
+          end if
+        end do
+      end subroutine nix_build
+
+      integer function nix_get(idx, target) result(res)
+        type(name_index), intent(in) :: idx
+        character(len=*), intent(in) :: target
+        character(len=NIX_KEYLEN) :: key
+        integer :: slot, probes
+        res = 0
+        if (idx%tsize == 0) return
+        key = target
+        slot = nix_hash(key, idx%tsize)
+        probes = 0
+        do
+          if (idx%vals(slot) == 0) return      !! empty slot -> not present
+          if (idx%keys(slot) == key) then
+            res = idx%vals(slot); return
+          end if
+          slot = slot + 1
+          if (slot > idx%tsize) slot = 1
+          probes = probes + 1
+          if (probes > idx%tsize) return       !! safety (full table)
+        end do
+      end function nix_get
+
+      end module name_index_module


### PR DESCRIPTION
hru_read resolves each HRU's topography, hydrology, soil, and field
database pointers by linearly scanning the database by name. On large
basins this is O(N_hru x N_db): a 94k-HRU model whose topography.hyd has
~104k entries performs up to ~9 billion character comparisons
(for_cpstr_eq) before day one (fewer with early-exit on match), and this
dominates startup.

Add a small open-addressing name->index hash (name_index_module), built
once per database, and replace the per-HRU linear scans with O(1) lookups.
First-match semantics are preserved (lowest index wins on duplicate
names), so the resolved indices are unchanged and results are identical.

Verification: NetCDF output is byte-identical to the unpatched build; text
output is identical except for the SWAT+ revision string in the file
header (which differs only because it reflects the build commit).

Measured on a 94,303-HRU basin: startup name-matching dropped by ~80-100 s
(print-scope dependent) to near zero, results unchanged. Negligible on
small models; the saving grows with HRU count.
