### PR TITLE
perf(varinit): reset only the active HRU's hhsedy row in the daily init

### DIFF
--- a/src/varinit.f90
+++ b/src/varinit.f90
@@ -124,7 +124,8 @@
       sedprev = 0.
       ubnrunoff = 0.
       irmmdt = 0.
-        hhsedy = 0.
+        hhsedy(j,:) = 0.    !! only this HRU's row; bare "hhsedy = 0." zeroed the whole
+                            !! (mhru x step) array on every HRU every day -> O(N_hru^2)/day
         ubntss = 0.
         wet_seep_day(j)%no3 = 0
         wet_seep_day(j)%nh3 = 0


### PR DESCRIPTION
varinit zeros hhsedy with an unindexed assignment (hhsedy = 0.), but
hhsedy is dimensioned (mhru, time%step). Every HRU's daily reset therefore
zeros the entire all-HRU array -- an O(N_hru^2)-per-day cost (~70 s of
memset on a 94k-HRU basin over 90 days, by VTune). Every other use of
hhsedy already indexes the active HRU (hhsedy(j,...)), and each HRU's row
is consumed within its own iteration, so only that row needs resetting.

Reset just the active row: hhsedy(j,:) = 0. (mirroring the existing
hhqday(j,:) pattern in the same routine). Results are unchanged: NetCDF
output byte-identical, text output identical apart from the revision
string in the file header. ~0.83 s/day saved on the 94k-HRU basin,
scaling with run length.
