### PR TITLE
Fix infinite loop in mgt_operatn when a schedule's operations all share one date

### DIFF
--- a/src/mgt_operatn.f90
+++ b/src/mgt_operatn.f90
@@ -37,6 +37,7 @@
       integer :: j = 0       !none          |HRU number
       real :: aphu = 0.      !heat units    |fraction of total heat units accumulated 
       integer :: isched = 0  !              |
+      integer :: iter_guard = 0 !           |full-pass guard against an infinite same-date loop
 
       j = ihru
       isched = hru(j)%mgt_ops
@@ -44,10 +45,20 @@
       
         mgt = sched(isched)%mgt_ops(hru(j)%cur_op)
 
+        iter_guard = 0
         do while(mgt%mon == time%mo .and. mgt%day == time%day_mo)
           call mgt_sched (isched)
           if (sched(isched)%num_ops == 1) exit
           if (yr_skip(j) == 1) exit
+          !! mgt_sched advances cur_op and wraps it back to 1 at the end of the schedule.
+          !! If every operation reachable from cur_op falls on this calendar date, the wrap
+          !! cycles op1 -> op2 -> ... -> op1 indefinitely: the date test never changes and
+          !! the two exits above never fire (e.g. an N-fert and a P-fert both dated on the
+          !! same day). Cap at one full pass through the schedule so each operation is
+          !! applied exactly once, then exit. This is a no-op for every non-degenerate
+          !! schedule, which cannot process more than num_ops operations on a single day.
+          iter_guard = iter_guard + 1
+          if (iter_guard >= sched(isched)%num_ops) exit
         end do
 
         ipl = Max(mgt%op2, 1)


### PR DESCRIPTION
### Bug

`mgt_operatn` applies the management operations scheduled for the current day in a loop:

```fortran
do while(mgt%mon == time%mo .and. mgt%day == time%day_mo)
  call mgt_sched (isched)
  if (sched(isched)%num_ops == 1) exit
  if (yr_skip(j) == 1) exit
end do
```

`mgt_sched` advances `cur_op` and **wraps it back to `1`** at the end of the schedule. If every operation reachable from `cur_op` falls on the current calendar date, the wrap cycles `op1 -> op2 -> ... -> op1` indefinitely — the `do while` date test never changes and the only two exits (`num_ops == 1`, `yr_skip == 1`) never fire. The run pins a core at 100% and never advances past that date.

### Reproducer

Any management schedule (assigned to an HRU land use) whose operations all share one date, with `num_ops > 1` — for example applying nitrogen and phosphorus fertilizer on the same day, which is routine agronomy:

```
past_fert     2          0
      fert    3  1  0.0  elem_n  broadcast  112.0
      fert    3  1  0.0  p       broadcast   20.0
```

The simulation hangs on 1 March of the first simulated year.

### Fix

Cap the same-date loop at `num_ops` iterations (one full pass through the schedule). Each operation is applied exactly once, then the loop exits. This is a no-op for every non-degenerate schedule, since a valid schedule can never process more than `num_ops` operations on a single day — verified by identical daily output on a non-degenerate model before/after the change.

The same wrap-based advance pattern exists in the heat-unit (`husc`) loop just below; I've left it untouched to keep this change minimal and focused on the reproduced defect, but I'm happy to guard it the same way if you'd prefer.
