### PR TITLE
Fix mgt_new_till_mix crash for plant communities with more than 12 pl…

### DIFF
--- a/src/mgt_biomix.f90
+++ b/src/mgt_biomix.f90
@@ -76,6 +76,8 @@
       mix_mn = mnz
       mix_mp = mpz
       mix_org%tot = orgz
+      if (allocated(mix_org%rsd)) deallocate (mix_org%rsd)
+      allocate (mix_org%rsd(pcom(jj)%npl))
       mix_org%rsd = orgz
       mix_org%hact = orgz
       mix_org%hsta = orgz
@@ -303,9 +305,10 @@
           endif
         endif
       endif
-      deallocate (sol_mass)    
-      deallocate (sol_msm)    
-      deallocate (sol_msn)    
-      deallocate (frac_dep)    
+      deallocate (sol_mass)
+      deallocate (sol_msm)
+      deallocate (sol_msn)
+      deallocate (frac_dep)
+      deallocate (mix_org%rsd)
       return
       end subroutine mgt_biomix

--- a/src/mgt_newtillmix_cswat0.f90
+++ b/src/mgt_newtillmix_cswat0.f90
@@ -66,6 +66,8 @@
       mix_mn = mnz
       mix_mp = mpz
       mix_org%tot = orgz
+      if (allocated(mix_org%rsd)) deallocate (mix_org%rsd)
+      allocate (mix_org%rsd(pcom(jj)%npl))
       mix_org%rsd = orgz
       mix_org%hact = orgz
       mix_org%hsta = orgz
@@ -226,11 +228,12 @@
           !end do
         end do
 
-        deallocate (sol_mass)    
-        deallocate (sol_msm)    
-        deallocate (sol_msn)    
-        deallocate (frac_dep)    
-    
+        deallocate (sol_mass)
+        deallocate (sol_msm)
+        deallocate (sol_msn)
+        deallocate (frac_dep)
+        deallocate (mix_org%rsd)
+
     end if
     return
     end subroutine mgt_newtillmix_cswat0

--- a/src/mgt_newtillmix_cswat1.f90
+++ b/src/mgt_newtillmix_cswat1.f90
@@ -67,6 +67,8 @@
       mix_mn = mnz
       mix_mp = mpz
       mix_org%tot = orgz
+      if (allocated(mix_org%rsd)) deallocate (mix_org%rsd)
+      allocate (mix_org%rsd(pcom(jj)%npl))
       mix_org%rsd = orgz
       mix_org%hact = orgz
       mix_org%hsta = orgz
@@ -241,9 +243,10 @@
         call mgt_tillfactor(jj,bio_mix_event,emix,dtil)
 
       endif
-      deallocate (sol_mass)    
-      deallocate (sol_msm)    
-      deallocate (sol_msn)    
-      deallocate (frac_dep)    
+      deallocate (sol_mass)
+      deallocate (sol_msm)
+      deallocate (sol_msn)
+      deallocate (frac_dep)
+      deallocate (mix_org%rsd)
       return
       end subroutine mgt_newtillmix_cswat1

--- a/src/organic_mineral_mass_module.f90
+++ b/src/organic_mineral_mass_module.f90
@@ -19,7 +19,7 @@
       type organic_mixing_mass           !       |used for each layer in mgt_newtillmix
         type (organic_mass) :: tot       !       |total organic pool
         type (organic_mass) :: surf_rsd  !   |fresh surface residue mixed into layers
-        type (organic_mass), dimension(12) :: rsd   !   |fresh soil residue (max 12 plants)
+        type (organic_mass), dimension(:), allocatable :: rsd   !   |fresh soil residue (dimensioned by number of plants in community)
         !! humus pools for old mineralization model (static carbon)
         type (organic_mass) :: hact      !       |active humus for old mineralization model
         type (organic_mass) :: hsta      !       |stable humus for old mineralization model


### PR DESCRIPTION
Fix mgt_new_till_mix crash for plant communities with more than 12 plants
mix_org%rsd in organic_mineral_mass_module.f90 was a fixed
dimension(12) array, so tillage/biomixing operations crashed with a
subscript-out-of-bounds error ("Subscript https://github.com/swat-model/swatplus/pull/1 of the array RSD has
value 13 which is greater than the upper bound of 12") on any plant
community with more than 12 plants. Made rsd allocatable and sized to
pcom(jj)%npl at the point of use in mgt_biomix, mgt_newtillmix_cswat0,
and mgt_newtillmix_cswat1, matching the existing local-scratch-array
allocation pattern already used in those subroutines (sol_mass,
sol_msm, sol_msn, frac_dep). Verified against communities with 1, 5,
12, 16, and 19 plants with no crash, no output differences for
existing <=12-plant communities, and full 46-year runs completing
successfully.

