### PR TITLE
Fix perennial root depth stuck at 25.4mm minimum at cold start

### DIFF
--- a/src/plant_init.f90
+++ b/src/plant_init.f90
@@ -338,6 +338,18 @@
           
           !! initialize plant mass if plant growing
           if (pcom(j)%plcur(ipl)%gro == "y") then
+            !! initialize phuacc_p (fraction of lifetime heat units accumulated) for perennials
+            !! that start the simulation already growing - otherwise it defaults to 0 and root
+            !! depth (which is driven by phuacc_p, not curyr_mat) floors at the 25.4mm minimum
+            !! regardless of the plant's declared maturity. Mirrors mgt_transplant.f90.
+            if (pldb(idp)%typ == "perennial") then
+              if (pcom(j)%plcur(ipl)%phumat_p > 0.) then
+                pcom(j)%plcur(ipl)%phuacc_p = pcomdb(icom)%pl(ipl)%fr_yrmat +  &
+                    (pcom(j)%plcur(ipl)%phumat * pcomdb(icom)%pl(ipl)%phuacc) / pcom(j)%plcur(ipl)%phumat_p
+              else
+                pcom(j)%plcur(ipl)%phuacc_p = pcomdb(icom)%pl(ipl)%fr_yrmat
+              end if
+            end if
             call pl_root_gro(j)
             call pl_seed_gro(j)
             call pl_partition(j, 1)


### PR DESCRIPTION
phuacc_p (fraction of a perennial's lifetime heat units accumulated) drives root depth in pl_root_gro.f90, but plant_init.f90 never assigned it for a plant that starts a simulation already growing - it stayed at its Fortran default of 0, forcing every perennial (e.g. a mature forest) to start with root depth floored at 25.4mm regardless of declared maturity (fr_yrmat), even though total biomass and root mass fraction initialized correctly via the separate curyr_mat/mat_yrs path.

Initialize phuacc_p using the same formula already used in mgt_transplant.f90 for mid-simulation perennial planting, guarded against phumat_p == 0 (possible if mat_yrs is unset for a perennial row) to avoid a NaN that would leave root depth stuck indefinitely.

Verified in an isolated test build against refdata/Ames_sub1 (forest HRU, fr_yrmat swept 0.1/0.5/1.0): root_dep now scales from 875mm to 2000mm (clipped to soil zmx) instead of staying pinned at 25.4mm, with an annual control case (oats) unaffected in every run.